### PR TITLE
Add OpenMayhem image generation, speech, and live media catalogs

### DIFF
--- a/OPENMAYHEM.md
+++ b/OPENMAYHEM.md
@@ -2,7 +2,7 @@
 
 ## Recommended first release
 
-Use the existing OpenAI-compatible chat backend with a named OpenMayhem preset. Keep signup, email/card verification, credit claims, key issuance, and payments on OpenMayhem. The user returns to RP Suite with an API key and chooses a model. This avoids introducing a second account system or embedding payment handling in a local roleplay client.
+Use the existing OpenAI-compatible chat backend with a named OpenMayhem preset, plus dedicated async image and speech adapters in the existing media workflows. Keep signup, email/card verification, credit claims, key issuance, and payments on OpenMayhem. The user returns to RP Suite with an API key and chooses a model. This avoids introducing a second account system or embedding payment handling in a local roleplay client.
 
 ```text
 RP Suite → OpenMayhem signup → claim eligible credit → create Chat API key
@@ -16,7 +16,7 @@ RP Suite browser → RP Suite local server → api.openmayhem.ai → provider ne
 | Topic | Evidence and integration decision |
 | --- | --- |
 | API | The [quickstart](https://openmayhem.ai/docs/quickstart) documents `https://api.openmayhem.ai/v1`, bearer keys, and Chat Completions. Reuse RP Suite's client for replies and background judges. |
-| Account and keys | Link to [signup](https://openmayhem.ai/signup), [credits](https://openmayhem.ai/dashboard/credits), and [API keys](https://openmayhem.ai/dashboard/keys). A Chat-scoped key is sufficient for this integration. |
+| Account and keys | Link to [signup](https://openmayhem.ai/signup), [credits](https://openmayhem.ai/dashboard/credits), and [API keys](https://openmayhem.ai/dashboard/keys). Enable Chat for conversation, Images for image generation, and Audio Speech for TTS. |
 | $5 offer | A direct read of the [featured campaign endpoint](https://api.openmayhem.ai/campaigns/featured) returned the `welcome` campaign with `credit_usd: "5.000000"` and `ends_at: "2026-09-14T14:22:00.000Z"`. This is a temporary offer, not a permanent signup entitlement. Fetch it dynamically and link to its offer page; otherwise link to credits. Claims require email/card verification and remain subject to eligibility. |
 | Browser access | A live OPTIONS request to `/v1/chat/completions` from `Origin: http://localhost:5173` returned 204 but no `Access-Control-Allow-Origin`. A preset alone would fail in RP Suite's browser. Forward through the existing local Express server. |
 | Model catalog | The public [catalog](https://api.openmayhem.ai/v1/models) returned 33 models across modalities, six with CHAT endpoints. One required tools and was unsuitable for normal conversation. Filter using endpoint and request-contract metadata; five conversational choices remained. Three had providers online at inspection time. Availability and prices change. |
@@ -30,12 +30,12 @@ RP Suite browser → RP Suite local server → api.openmayhem.ai → provider ne
 
 ## Implementation boundaries
 
-- The local router has three fixed upstream destinations: public chat catalog, public featured campaign, and authenticated Chat Completions. It does not accept arbitrary upstream URLs, forward cookies, follow redirects, persist credentials, or retry requests. RP Suite's origin guard applies before it.
+- The local router exposes fixed paths for the public catalog/campaign, authenticated Chat Completions, Images, Audio Speech, job status/cancellation, and owned artifacts. It validates modality/cursor queries and resource IDs, does not accept caller-provided upstream URLs, forward cookies, persist credentials, or retry inference. Artifact redirects are accepted only from the fixed API, require HTTPS, and receive no bearer credentials. Other redirects are rejected. RP Suite's origin guard applies before it.
 - Keys stay in the existing browser settings storage and pass transiently through the RP Suite server for inference. Changing providers clears the previous key and model, preventing automatic probes from sending another provider's credentials to OpenMayhem or vice versa.
-- Both onboarding surfaces share the same instructions. Public catalog queries do not send the API key. Model metadata is briefly cached and refreshed by Test connection.
-- Both model dropdowns require a positive `providers_available` count and exclude stale availability. Busy-only, offline, and unknown availability are not selectable. The public list refreshes every 30 seconds while mounted and when the window regains focus. If no providers are available, show an empty disabled dropdown instead of falling back to manual entry. Keep metadata for saved selections separately so temporary provider load does not discard the chosen model's contract. Availability can still change between selection and dispatch; the provider's response remains authoritative.
+- Both onboarding surfaces share the same instructions. Public catalog queries do not send the API key. Every catalog page is fetched using next_cursor; endpoint caches are separate. Metadata is briefly cached and can be refreshed manually.
+- All chat, image, and speech model dropdowns require a positive `providers_available` count and exclude stale availability. Busy-only, offline, and unknown availability are not selectable. The public list refreshes every 30 seconds while mounted and when the window regains focus. If no providers are available, show an empty disabled dropdown instead of falling back to manual entry. Keep metadata for saved selections separately so temporary provider load does not discard the chosen model's contract. Availability can still change between selection and dispatch; the provider's response remains authoritative.
 - Account credit is spent by visible replies and by relationship scoring, suggestions, and other background AI calls. The integration does not grant credits or assert that every account is eligible.
-- Images, speech, receipt-based cost displays, routing/trust controls, and an account-linking protocol are outside this initial chat PR.
+- Receipt-based cost displays, routing/trust controls, voice cloning, and an account-linking protocol remain outside this PR.
 
 ## Follow-up recommendation for OpenMayhem
 
@@ -67,3 +67,26 @@ A separate four-turn Sumire conversation was exercised through the actual browse
 - Suggested choices rendered, but one set included accepting a pastry gift that had never been offered. JSON mode solves output structure, not grounding in the conversation.
 
 The integration is usable for exploratory play. Before recommending a default roleplay model, compare conversation quality across models and improve ownership checks for remembered facts and transcript grounding for suggested actions. These observations do not establish whether the remaining quality issues originate in the model, prompt construction, or memory/choice processing. This UI session is additional to the four-call cost measurement above.
+
+
+## Images and speech
+
+The [media documentation](https://openmayhem.ai/docs/media) describes asynchronous jobs for both `/v1/images/generations` and `/v1/audio/speech`. These endpoints do not return the inline image/audio responses used by many other OpenAI-compatible services. The [routing documentation](https://openmayhem.ai/docs/routing) documents cursor pagination and live availability. Both were cross-checked against the local OpenMayhem API source and the production catalog.
+
+- Settings > Images and Settings > Voice each offer OpenMayhem and an independent live model selection. One dedicated OpenMayhem media key is shared by those two features; a button can explicitly copy the chat key. This lets images and speech work even when chat uses a different provider. The media key is never passed to another provider.
+- New compatible models appear automatically from all catalog pages. Models need a positive available-provider count and non-stale availability. Required inputs must be supported by RP Suite; reference-media-only and non-playable speech contracts are excluded. Catalog errors and all-offline states show no selectable models. A saved selection is retained but is not added back as an available option. Availability can change before dispatch; media requests recheck it immediately before submission.
+- Image generation uses the model's advertised steps/guidance defaults, one image per job, and dimensions fitted to the slot's aspect ratio and the model's size constraints. For Z-Image Turbo this avoids RP Suite's local default of 28 steps exceeding its 7-9 step contract. A fresh random seed is sent when no seed is specified. PNG/JPEG/WebP MIME types are preserved through avatar, sprite, background, and gallery paths.
+- Jobs are submitted once, polled, and downloaded by validated resource IDs. Generation has a five-minute overall deadline. Stop/unmount requests DELETE for an unfinished job, including when Stop arrives before submission returns its ID. Failed cancellation is reported honestly, and a lost submission response directs the user to check their dashboard before retrying. Work already performed may still be billed.
+- Speech uses the selected model's published voices and a browser-playable format. The same model/key serves the settings preview and Visual Novel manual/automatic voice. Character voice IDs are selected from that contract; a different provider override requires configuring that provider globally first so credentials cannot go to the wrong service. Unsupported voices and overlong text fail before a billed submission. Changing lines/settings or stopping aborts pending OpenMayhem speech and releases audio URLs.
+- Saved generated images are downloaded into RP Suite's existing local asset storage; they do not depend on expiring OpenMayhem artifact URLs. Audio is fetched for playback on demand, without a persistent speech cache.
+
+Production catalog inspection on September 9 found `tongyi/z-image-turbo` (image generation) and `resembleai/chatterbox` (speech), with Chatterbox exposing only the `default` voice. These IDs and voices are observations, not hardcoded options.
+
+Live browser verification used the supplied key to generate and display a 768x768 watercolor lighthouse through Settings > Images, and to synthesize/play the voice settings test phrase. Visual Novel read-aloud was exercised with the existing isolated Qwen test conversation. Automated coverage includes paginated model discovery, offline/stale/incompatible filtering, contract adaptation, voice validation, async polling/downloads, cancellation before the job ID arrives, failed cancellation, terminal/provider errors, incorrect artifacts, and credential isolation. Real insufficient-credit exhaustion and every possible future model remain untested.
+
+
+Final media validation: **2,027 tests across 109 files**, full TypeScript checks, and production build passed. A later live cancellation fix was rechecked with the 23 focused media/router tests. The browser tests also generated an 832x1216 lighthouse-keeper portrait, saved/reopened it from `/avatars/characters/.../avatar.png`, selected/saved the supported character voice override, and generated/saved one Neutral expression through the batch workflow. A separate media-test character was retained locally.
+
+During the final live catalog comparison, `qwen/qwen3.8-27b` changed to zero available providers and correctly disappeared from the chat dropdown. Images and speech retained their separate saved model choices across navigation/reloads.
+
+The browser Stop test exposed a production-specific rejection of a bodyless DELETE carrying JSON Content-Type. The relay now sends Content-Type only for POST bodies; regression tests cover this. A fresh live speech job returned 202/running, its cancellation request returned 200/running, and the browser Stop retest returned to idle without the earlier error. This confirms cancellation acceptance, not instantaneous provider termination or a refund. The earlier failed-cancellation job had already completed when inspected and cost $0.000181; this is not the total test spend.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ environment variables and exposing it beyond localhost.
 
 KoboldCpp is the main target, with streaming, vision, abort handling and token counting written against its own API rather than a lowest common denominator. Any OpenAI-compatible endpoint also works: OpenRouter, Nano-GPT, LM Studio, llama.cpp, TabbyAPI, oobabooga. NovelAI is supported for both text and images, with its own tokenizer.
 
-Each backend reports its connection state in the header, and Settings has a Test connection button that hits a free metadata endpoint instead of burning a real generation on a paid provider.
+Each chat backend reports its connection state in the header. The chat connection test reads free metadata; image and voice tests perform real generation.
 
 ### OpenMayhem
 
@@ -60,6 +60,10 @@ Choose **OpenAI-compatible → OpenMayhem** in Settings → Connection, or selec
 OpenMayhem uses `https://api.openmayhem.ai/v1`. Requests pass through RP Suite's local server because the hosted API currently restricts browser origins. The server forwards your key without storing it. Replies and background scoring both use your credit. The free-credit amount and availability come from OpenMayhem, and eligibility/verification are handled there.
 
 The connection check reads the public catalog without spending credit; it does **not** validate your key or balance. Those are checked on your first inference request. See [OpenMayhem integration notes](OPENMAYHEM.md) for behavior, research, and validation limits.
+
+For images and speech, choose **OpenMayhem** in **Settings > Images** and **Settings > Voice**. Enter a media key with Images and Audio Speech permissions (or use the button to copy your OpenMayhem chat key), then choose each model. Voice options also come from the selected model. The image preview and voice test perform real, billed generation.
+
+All three model lists load every catalog page and refresh every 30 seconds and on window focus. Only compatible models with available, non-stale providers are selectable, so newly added live models appear automatically. Images use model sampling defaults and slot dimensions adapted to its limits. Stop requests media-job cancellation; completed work may still cost credit. Generated assets saved to a character or world remain stored locally.
 
 ### Characters
 

--- a/server/openMayhem.test.ts
+++ b/server/openMayhem.test.ts
@@ -73,4 +73,42 @@ describe('OpenMayhem local forwarding', () => {
     expect(result.status).toBe(502)
     expect(result.body).not.toContain('private diagnostic')
   })
+  it('forwards validated modality and cursor queries without exposing credentials', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('{"data":[]}'))
+    expect((await call('/models?endpoint_family=AUDIO_SPEECH&cursor=page%2F%2B2', 'GET', { Authorization: 'Bearer secret' })).status).toBe(200)
+    expect(fetchMock.mock.calls[0][0]).toBe('https://api.openmayhem.ai/v1/models?endpoint_family=AUDIO_SPEECH&limit=100&cursor=page%2F%2B2')
+    expect(fetchMock.mock.calls[0][1].headers).toEqual({ Accept: 'application/json' })
+    expect((await call('/models?endpoint_family=ANYTHING')).status).toBe(400)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+  it('requires authorization for job status, cancellation, artifacts and both generation endpoints', async () => {
+    for (const [path, method] of [['/jobs/job_1', 'GET'], ['/jobs/job_1', 'DELETE'], ['/artifacts/a_1', 'GET'], ['/images/generations', 'POST'], ['/audio/speech', 'POST']]) {
+      expect((await call(path, method)).status).toBe(401)
+      fetchMock.mockResolvedValueOnce(new Response('{}'))
+      expect((await call(path, method, { Authorization: 'Bearer media-key' }, method === 'POST' ? { model: 'test' } : undefined)).status).toBe(200)
+      expect(fetchMock.mock.lastCall?.[0]).toBe(`https://api.openmayhem.ai/v1${path}`)
+      expect(fetchMock.mock.lastCall?.[1].headers.Authorization).toBe('Bearer media-key')
+      if (method !== 'POST') {
+        expect(fetchMock.mock.lastCall?.[1].headers['Content-Type']).toBeUndefined()
+        expect(fetchMock.mock.lastCall?.[1].body).toBeUndefined()
+      }
+    }
+  })
+  it('downloads a signed artifact redirect without forwarding the bearer or cookies', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 302, headers: { Location: 'https://bucket.s3.amazonaws.com/signed-artifact?signature=abc' } }))
+      .mockResolvedValueOnce(new Response('audio bytes', { headers: { 'Content-Type': 'audio/wav' } }))
+    const result = await call('/artifacts/a_1', 'GET', { Authorization: 'Bearer media-key', Cookie: 'session=private' })
+    expect(result.status).toBe(200)
+    expect(result.body).toBe('audio bytes')
+    expect(fetchMock.mock.calls[0][1].redirect).toBe('manual')
+    expect(fetchMock.mock.calls[1][1]).toMatchObject({ redirect: 'error', headers: { Accept: expect.any(String) } })
+    expect(fetchMock.mock.calls[1][1].headers.Authorization).toBeUndefined()
+    expect(fetchMock.mock.calls[1][1].headers.Cookie).toBeUndefined()
+  })
+  it('rejects insecure artifact redirects and invalid resource IDs', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 302, headers: { Location: 'http://localhost/private' } }))
+    expect((await call('/artifacts/a_1', 'GET', { Authorization: 'Bearer media-key' })).status).toBe(502)
+    expect((await call('/jobs/not%20an%20id', 'DELETE', { Authorization: 'Bearer media-key' })).status).toBe(400)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
 })

--- a/server/openMayhem.ts
+++ b/server/openMayhem.ts
@@ -4,35 +4,68 @@ import { pipeline } from 'node:stream/promises'
 
 const UPSTREAM = 'https://api.openmayhem.ai'
 
-/** Fixed destinations only. Never persist keys, forward cookies, follow redirects, or retry inference. */
+/** Fixed API destinations. Artifact redirects come only from that API and receive no credentials. */
 export function openMayhemRouter() {
   const router = Router()
   const routes = [
     ['get', '/models', '/v1/models?endpoint_family=CHAT&limit=100'],
     ['get', '/campaign', '/campaigns/featured'],
     ['post', '/chat/completions', '/v1/chat/completions'],
+    ['post', '/images/generations', '/v1/images/generations'],
+    ['post', '/audio/speech', '/v1/audio/speech'],
+    ['get', '/jobs/:id', '/v1/jobs/'],
+    ['delete', '/jobs/:id', '/v1/jobs/'],
+    ['get', '/artifacts/:id', '/v1/artifacts/'],
   ] as const
   for (const [method, localPath, remotePath] of routes) {
     router[method](localPath, async (req, res) => {
       const authorization = req.get('authorization')
-      if (method === 'post' && !/^Bearer\s+\S+$/.test(authorization ?? '')) {
+      const isPublic = localPath === '/models' || localPath === '/campaign'
+      let destination = `${UPSTREAM}${remotePath}`
+      if (localPath === '/models') {
+        const endpoint = req.query.endpoint_family ?? 'CHAT'
+        const cursor = req.query.cursor
+        if (!['CHAT', 'IMAGES', 'AUDIO_SPEECH'].includes(endpoint as string)
+          || (cursor !== undefined && (typeof cursor !== 'string' || cursor.length > 4096))) {
+          res.status(400).json({ error: { message: 'Invalid model catalog query.' } }); return
+        }
+        const query = new URLSearchParams({ endpoint_family: endpoint as string, limit: '100' })
+        if (cursor) query.set('cursor', cursor as string)
+        destination = `${UPSTREAM}/v1/models?${query}`
+      }
+      if (localPath.includes(':id')) {
+        const id = (req.params as Record<string, string>).id
+        if (!/^[a-zA-Z0-9_-]{1,200}$/.test(id)) {
+          res.status(400).json({ error: { message: 'Invalid OpenMayhem resource ID.' } }); return
+        }
+        destination += id
+      }
+      if (!isPublic && !/^Bearer\s+\S+$/.test(authorization ?? '')) {
         res.status(401).json({ error: { message: 'Enter your OpenMayhem API key first.' } })
         return
       }
       const controller = new AbortController()
-      const timer = setTimeout(() => controller.abort(), method === 'post' ? 180000 : 10000)
+      const timer = setTimeout(() => controller.abort(), isPublic ? 10000 : 180000)
       const close = () => controller.abort()
       res.on('close', close)
       try {
-        const upstream = await fetch(`${UPSTREAM}${remotePath}`, {
+        let upstream = await fetch(destination, {
           method: method.toUpperCase(),
-          headers: method === 'post'
-            ? { 'Content-Type': 'application/json', Authorization: authorization! }
+          headers: !isPublic
+            ? { ...(method === 'post' ? { 'Content-Type': 'application/json' } : { Accept: 'application/json' }), Authorization: authorization! }
             : { Accept: 'application/json' },
           ...(method === 'post' ? { body: JSON.stringify(req.body) } : {}),
-          redirect: 'error',
+          redirect: localPath === '/artifacts/:id' ? 'manual' : 'error',
           signal: controller.signal,
         })
+        if (localPath === '/artifacts/:id' && [301, 302, 303, 307, 308].includes(upstream.status)) {
+          const location = new URL(upstream.headers.get('location') || '', UPSTREAM)
+          if (location.protocol !== 'https:' || location.username || location.password || location.origin === UPSTREAM) {
+            throw new Error('Invalid artifact redirect')
+          }
+          await upstream.body?.cancel()
+          upstream = await fetch(location, { redirect: 'error', signal: controller.signal, headers: { Accept: 'image/*, audio/*, application/octet-stream' } })
+        }
         res.status(upstream.status)
         res.setHeader('Cache-Control', 'no-store')
         for (const name of ['content-type', 'retry-after', 'x-request-id', 'x-openmayhem-stream-mode']) {

--- a/src/components/characters/CharacterEditor.tsx
+++ b/src/components/characters/CharacterEditor.tsx
@@ -43,6 +43,8 @@ import { RegenerateFieldButton } from './RegenerateFieldButton'
 import { LorebookEditor } from '@/components/worldinfo/LorebookEditor'
 import { getGiftCatalog } from '@/lib/dating/gifts'
 import { useSettingsStore } from '@/lib/store/useSettingsStore'
+import { useOpenMayhemModels } from '@/lib/hooks/useOpenMayhemModels'
+import { OpenMayhemVoiceField } from '@/components/settings/OpenMayhemVoiceField'
 import { maximumImmersionChecklist, maximumImmersionSamplerParams, maximumImmersionSystemPrompt } from '@/lib/prompt/immersionPreset'
 import {
   PHASES,
@@ -206,6 +208,10 @@ export function CharacterEditor({
   const [weatherHates, setWeatherHates] = useState<WeatherKind[]>(character?.weatherPreferences?.hates ?? [])
   const [schedule, setSchedule] = useState<ScheduleEntry[]>(character?.schedule ?? [])
   const [voiceProvider, setVoiceProvider] = useState<TtsProviderId | ''>(character?.voice?.provider ?? '')
+  const globalTtsProvider = useSettingsStore((s) => s.ttsProvider)
+  const globalTtsModel = useSettingsStore((s) => s.ttsModel)
+  const usesOpenMayhemVoice = (voiceProvider || globalTtsProvider) === 'openmayhem'
+  const { models: speechModels } = useOpenMayhemModels('AUDIO_SPEECH', tab === 'voice' && usesOpenMayhemVoice)
   const [voiceId, setVoiceId] = useState(character?.voice?.voiceId ?? '')
   const [verbalTics, setVerbalTics] = useState<string[]>(character?.voiceFingerprint?.verbalTics ?? [])
   const [catchphrases, setCatchphrases] = useState<string[]>(character?.voiceFingerprint?.catchphrases ?? [])
@@ -1687,7 +1693,7 @@ export function CharacterEditor({
       {tab === 'voice' && (
         <Section
           title="Voice"
-          description="Overrides the global Settings → Voice provider/voice when this character's lines are read aloud in Visual Novel mode. Leave blank to use the global default."
+          description="Leave blank to use the global voice. A provider override must match Settings → Voice, where its key and model are configured. OpenMayhem voices use that speech model."
           surface="bare"
         >
           <div className="grid grid-cols-1 gap-x-3 sm:grid-cols-2">
@@ -1699,12 +1705,12 @@ export function CharacterEditor({
                 </option>
               ))}
             </SelectField>
-            <TextField
+            {usesOpenMayhemVoice ? <OpenMayhemVoiceField model={speechModels?.find((m) => m.id === globalTtsModel)} value={voiceId} onChange={setVoiceId} label="Voice / speaker ID override" placeholder="Use global voice" /> : <TextField
               label="Voice / speaker ID override"
               value={voiceId}
               onChange={(e) => setVoiceId(e.target.value)}
               placeholder="Leave blank to use the global voice"
-            />
+            />}
           </div>
         </Section>
       )}

--- a/src/components/characters/GenerateExpressionSetDialog.tsx
+++ b/src/components/characters/GenerateExpressionSetDialog.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useSettingsStore } from '@/lib/store/useSettingsStore'
 import { createImageBackend } from '@/lib/api/createImageBackend'
 import { errorMessage } from '@/lib/store/useToastStore'
@@ -44,6 +44,8 @@ export function GenerateExpressionSetDialog({
   // itself in the loop below would silently never actually stop anything. The ref is mutated
   // in-place and read fresh every iteration, so the check below always sees the current value.
   const stopRef = useRef(false)
+  const controllerRef = useRef<AbortController | null>(null)
+  useEffect(() => () => { stopRef.current = true; controllerRef.current?.abort() }, [])
   const [progress, setProgress] = useState<{ done: number; total: number; currentLabel: string | null }>({
     done: 0,
     total: 0,
@@ -51,6 +53,7 @@ export function GenerateExpressionSetDialog({
   })
   const [results, setResults] = useState<{ succeeded: string[]; failed: string[] } | null>(null)
 
+  const openMayhemApiKey = useSettingsStore((s) => s.openMayhemApiKey)
   const imageBackend = useSettingsStore((s) => s.imageBackend)
   const imageBackendBaseUrl = useSettingsStore((s) => s.imageBackendBaseUrl)
   const imageBackendUsername = useSettingsStore((s) => s.imageBackendUsername)
@@ -70,10 +73,12 @@ export function GenerateExpressionSetDialog({
     setBusy(true)
     setStopRequested(false)
     stopRef.current = false
+    const controller = new AbortController()
+    controllerRef.current = controller
     setResults(null)
     setProgress({ done: 0, total: targets.length, currentLabel: targets[0].label })
 
-    const backend = createImageBackend({ imageBackend, imageBackendBaseUrl, imageBackendUsername, imageBackendPassword, imageBackendModel })
+    const backend = createImageBackend({ openMayhemApiKey, imageBackend, imageBackendBaseUrl, imageBackendUsername, imageBackendPassword, imageBackendModel })
     const succeeded: string[] = []
     const failed: string[] = []
 
@@ -89,12 +94,13 @@ export function GenerateExpressionSetDialog({
           steps: 28,
           cfgScale: 7,
           model: imageBackendModel || undefined,
-        })
+        }, controller.signal)
+        controller.signal.throwIfAborted()
         if (!result.base64) throw new Error('The backend returned no image data.')
-        onGenerated(exp.id, `data:image/png;base64,${result.base64}`)
+        onGenerated(exp.id, `data:${result.mimeType || 'image/png'};base64,${result.base64}`)
         succeeded.push(exp.label)
       } catch (e) {
-        failed.push(`${exp.label} (${errorMessage(e)})`)
+        if (!(e instanceof DOMException && e.name === 'AbortError')) failed.push(`${exp.label} (${errorMessage(e)})`)
       }
       setProgress({ done: i + 1, total: targets.length, currentLabel: exp.label })
     }
@@ -154,6 +160,7 @@ export function GenerateExpressionSetDialog({
               variant="ghost"
               onClick={() => {
                 stopRef.current = true
+                controllerRef.current?.abort()
                 setStopRequested(true)
               }}
               disabled={stopRequested}

--- a/src/components/chat/VNStage.tsx
+++ b/src/components/chat/VNStage.tsx
@@ -467,10 +467,17 @@ export function VNStage({
   const ttsApiKey = useSettingsStore((s) => s.ttsApiKey)
   const ttsBaseUrl = useSettingsStore((s) => s.ttsBaseUrl)
   const ttsRegion = useSettingsStore((s) => s.ttsRegion)
+  const ttsModel = useSettingsStore((s) => s.ttsModel)
+  const openMayhemApiKey = useSettingsStore((s) => s.openMayhemApiKey)
   const ttsVoice = useSettingsStore((s) => s.ttsVoice)
   const [speakState, setSpeakState] = useState<'idle' | 'loading' | 'playing'>('idle')
   const speakAudioRef = useRef<HTMLAudioElement | null>(null)
+  const speakControllerRef = useRef<AbortController | null>(null)
+  const speakUrlRef = useRef<string | null>(null)
   const stopSpeaking = () => {
+    speakControllerRef.current?.abort()
+    speakControllerRef.current = null
+    if (speakUrlRef.current) { URL.revokeObjectURL(speakUrlRef.current); speakUrlRef.current = null }
     speakAudioRef.current?.pause()
     speakAudioRef.current = null
     setSpeakState('idle')
@@ -483,20 +490,29 @@ export function VNStage({
     const text = toSpeakableText(rawText)
     if (!text) return
     setSpeakState('loading')
+    const controller = new AbortController()
+    speakControllerRef.current = controller
     try {
+      if (character?.voice?.provider && character.voice.provider !== ttsProvider) {
+        throw new Error('This character overrides the voice provider. Select that provider in Settings → Voice first, or use the global default for this character.')
+      }
       const blob = await synthesizeSpeech(
         {
           provider: character?.voice?.provider ?? ttsProvider,
-          apiKey: ttsApiKey,
+          apiKey: ttsProvider === 'openmayhem' ? openMayhemApiKey : ttsApiKey,
+          model: ttsModel,
           baseUrl: ttsBaseUrl,
           region: ttsRegion,
           voice: character?.voice?.voiceId || ttsVoice,
         },
         text,
         koboldBaseUrl,
+        controller.signal,
       )
+      controller.signal.throwIfAborted()
       const url = URL.createObjectURL(blob)
       const audio = new Audio(url)
+      speakUrlRef.current = url
       speakAudioRef.current = audio
       setSpeakState('playing')
       const finish = () => {
@@ -508,8 +524,12 @@ export function VNStage({
       }
       audio.onended = finish
       audio.onerror = finish
-      await audio.play().catch(finish)
+      try { await audio.play() } catch (error) { finish(); throw error }
     } catch (e) {
+      if (controller.signal.aborted) {
+        if (!(e instanceof DOMException && e.name === 'AbortError')) toastError(errorMessage(e))
+        return
+      }
       setSpeakState('idle')
       toastError(errorMessage(e))
     }
@@ -524,7 +544,7 @@ export function VNStage({
   }
   // Swiping to a different line, or leaving the message entirely, cuts off whatever was playing —
   // it no longer matches what's on screen.
-  useEffect(() => stopSpeaking, [lastCharMsg?.id, activeSwipe])
+  useEffect(() => stopSpeaking, [lastCharMsg?.id, activeSwipe, ttsProvider, ttsModel, ttsVoice, openMayhemApiKey, ttsApiKey, ttsBaseUrl, ttsRegion, character?.voice?.provider, character?.voice?.voiceId])
   const [autoVoice, setAutoVoice] = useState(false)
 
   // Every message id this component instance has watched stream in live — its text already

--- a/src/components/settings/ImageGenSettings.tsx
+++ b/src/components/settings/ImageGenSettings.tsx
@@ -1,3 +1,9 @@
+import { useState } from 'react'
+import { useOpenMayhemModels } from '@/lib/hooks/useOpenMayhemModels'
+import { OpenMayhemModelSelect } from './OpenMayhemModelSelect'
+import { OpenMayhemMediaKey } from './OpenMayhemMediaKey'
+import { Button } from '@/components/ui/Button'
+import { GenerateImageButton } from '@/components/ui/GenerateImageButton'
 import { useSettingsStore } from '@/lib/store/useSettingsStore'
 import { IMAGE_BACKEND_LABELS, type ImageBackendId } from '@/lib/api/imageBackend'
 import { NOVELAI_IMAGE_MODELS } from '@/lib/api/novelaiImage'
@@ -13,15 +19,6 @@ const LOCAL_BACKEND_DEFAULTS: Record<'a1111' | 'comfyui' | 'swarmui', string> = 
   swarmui: 'http://127.0.0.1:7801',
 }
 
-/**
- * Section 11's "image/asset generation backends" — none of these four has been run against a real
- * server this session (no local install, and NovelAI needs the same paid subscription its text
- * backend does). Built to each project's own documented API, same honesty bar as every other
- * unverified backend in this app: sanity-check the first real generation before trusting it. This
- * settings page only configures a shared connection; where a generation actually happens (a
- * character portrait, a VN sprite, a background) is a separate, much smaller follow-up — see
- * ROADMAP.md section 11's own remaining "generate directly into a slot" item.
- */
 export function ImageGenSettings() {
   const imageBackend = useSettingsStore((s) => s.imageBackend)
   const imageBackendBaseUrl = useSettingsStore((s) => s.imageBackendBaseUrl)
@@ -30,13 +27,16 @@ export function ImageGenSettings() {
   const imageBackendModel = useSettingsStore((s) => s.imageBackendModel)
   const setImageBackendConfig = useSettingsStore((s) => s.setImageBackendConfig)
 
+  const { models, loading, reload } = useOpenMayhemModels('IMAGES', imageBackend === 'openmayhem')
+  const [preview, setPreview] = useState('')
+
   const isLocal = imageBackend === 'a1111' || imageBackend === 'comfyui' || imageBackend === 'swarmui'
 
   return (
     <SettingsPage>
       <Section
         title="Image generation"
-        description="Generates portraits, sprites, gallery CGs, and backgrounds. None of these four have been run against a real server yet (see ROADMAP.md section 11); each is built to that project's own documented API."
+        description="Generates portraits, sprites, gallery CGs, and backgrounds using the backend selected here."
         surface="bare"
       >
         <SelectField
@@ -47,7 +47,7 @@ export function ImageGenSettings() {
             const patch: Parameters<typeof setImageBackendConfig>[0] = { imageBackend: backend }
             // A fresh local-backend pick with no URL yet gets a sane default instead of a blank
             // field — the same convenience the chat-backend provider picker already gives.
-            if (backend !== 'novelai-image' && !imageBackendBaseUrl) {
+            if ((backend === 'a1111' || backend === 'comfyui' || backend === 'swarmui') && !imageBackendBaseUrl) {
               patch.imageBackendBaseUrl = LOCAL_BACKEND_DEFAULTS[backend]
             }
             setImageBackendConfig(patch)
@@ -59,6 +59,19 @@ export function ImageGenSettings() {
             </option>
           ))}
         </SelectField>
+
+        {imageBackend === 'openmayhem' && <>
+          <OpenMayhemMediaKey />
+          <OpenMayhemModelSelect kind="image" models={models?.map((m) => m.id) ?? null} loading={loading} value={imageBackendModel}
+            onChange={(model) => { setImageBackendConfig({ imageBackendModel: model }); setPreview('') }} />
+          <Button onClick={reload} disabled={loading}>Refresh models</Button>
+          <p className="my-3 text-xs text-text-muted">Uses the selected model's default steps and guidance. Image dimensions fit the slot and the model's limits. Each image is a billed job; stopping requests cancellation, but work already done may still be billed.</p>
+          <div className="relative flex items-center gap-2">
+            <span className="text-sm">Test image generation</span>
+            <GenerateImageButton label="Test image generation" width={768} height={768} initialPrompt="A small lighthouse on a quiet green island, watercolor illustration, no text" onGenerated={setPreview} />
+          </div>
+          {preview && <img src={preview} alt="OpenMayhem test generation" className="mt-3 max-h-72 rounded-xl" />}
+        </>}
 
         {isLocal && (
           <TextField
@@ -133,7 +146,7 @@ export function ImageGenSettings() {
         )}
 
         <p className="mt-2 text-xs text-text-muted">
-          {imageBackend === 'novelai-image'
+          {imageBackend === 'openmayhem' ? 'Images are downloaded into RP Suite, so saved assets remain available after OpenMayhem artifacts expire.' : imageBackend === 'novelai-image'
             ? 'Keys are stored only in this browser and sent directly to NovelAI. Never through any other server.'
             : 'Requests go straight from this browser to the server URL above. Never through any other server.'}
         </p>

--- a/src/components/settings/OpenMayhemMediaKey.tsx
+++ b/src/components/settings/OpenMayhemMediaKey.tsx
@@ -1,0 +1,19 @@
+import { useSettingsStore } from '@/lib/store/useSettingsStore'
+import { isOpenMayhem } from '@/lib/api/openMayhem'
+import { TextField } from '@/components/ui/Field'
+import { Button } from '@/components/ui/Button'
+import { OpenMayhemSetup } from './OpenMayhemSetup'
+
+export function OpenMayhemMediaKey() {
+  const key = useSettingsStore((s) => s.openMayhemApiKey)
+  const setKey = useSettingsStore((s) => s.setOpenMayhemApiKey)
+  const chatKey = useSettingsStore((s) => s.chatBackendApiKey)
+  const chatUrl = useSettingsStore((s) => s.chatBackendBaseUrl)
+  const chatBackend = useSettingsStore((s) => s.chatBackend)
+  return <>
+    <OpenMayhemSetup media />
+    <TextField label="OpenMayhem media API key" type="password" value={key} onChange={(e) => setKey(e.target.value)}
+      hint="Shared by OpenMayhem Images and Voice. Stored in this browser; requests pass through RP Suite's local relay to OpenMayhem." />
+    {chatBackend === 'openai-compatible' && isOpenMayhem(chatUrl) && chatKey && <Button onClick={() => setKey(chatKey)}>Use OpenMayhem chat key</Button>}
+  </>
+}

--- a/src/components/settings/OpenMayhemModelSelect.tsx
+++ b/src/components/settings/OpenMayhemModelSelect.tsx
@@ -1,6 +1,7 @@
 import { SelectField } from '@/components/ui/Field'
 
-export function OpenMayhemModelSelect({ models, loading, value, onChange }: {
+export function OpenMayhemModelSelect({ models, loading, value, onChange, kind = 'chat' }: {
+  kind?: 'chat' | 'image' | 'speech'
   models: string[] | null
   loading: boolean
   value: string
@@ -9,8 +10,8 @@ export function OpenMayhemModelSelect({ models, loading, value, onChange }: {
   const options = models ?? []
   const selected = options.includes(value)
   const hint = loading ? 'Checking available providers…'
-    : models === null ? 'Could not check model availability. Use Test connection to retry.'
-      : options.length === 0 ? 'No chat models currently have an available provider. This list refreshes automatically.'
+    : models === null ? 'Could not check model availability. Refresh the model list to retry.'
+      : options.length === 0 ? `No ${kind} models currently have an available compatible provider. This list refreshes automatically.`
         : value && !selected ? 'The selected model is currently unavailable. Choose another model or wait for it to return.'
           : 'Only models with an available provider. Refreshes every 30 seconds and when you return to this window.'
   return (

--- a/src/components/settings/OpenMayhemSetup.tsx
+++ b/src/components/settings/OpenMayhemSetup.tsx
@@ -5,7 +5,7 @@ type Offer = { slug: string; credit_usd: string; ends_at: string | null }
 const LINK = 'text-accent hover:underline'
 
 /** Account creation and credit claims stay on OpenMayhem; RP Suite only receives an API key. */
-export function OpenMayhemSetup() {
+export function OpenMayhemSetup({ media = false }: { media?: boolean }) {
   const [offer, setOffer] = useState<Offer | null>(null)
   useEffect(() => {
     const controller = new AbortController()
@@ -37,10 +37,10 @@ export function OpenMayhemSetup() {
             <a className={LINK} href="https://openmayhem.ai/dashboard/credits" target="_blank" rel="noopener noreferrer">Check credits and current offers</a> on OpenMayhem.
           </>}
         </li>
-        <li><a className={LINK} href="https://openmayhem.ai/dashboard/keys" target="_blank" rel="noopener noreferrer">Create an API key</a> with Chat permission, paste it below, then choose a model.</li>
+        <li><a className={LINK} href="https://openmayhem.ai/dashboard/keys" target="_blank" rel="noopener noreferrer">Create an API key</a> with {media ? 'Images and Audio Speech' : 'Chat'} permission, paste it below, then choose a model.</li>
       </ol>
-      <p className="mt-3">Replies and background scoring use your OpenMayhem credits. Chats stay saved here; prompts and your key pass through your RP Suite server to OpenMayhem for inference.</p>
-      <p className="mt-2">Thinking is disabled when the model supports it so short replies and scoring calls have room to answer. Stopping a reply may still incur the provider’s generation cost.</p>
+      <p className="mt-3">{media ? 'Images and speech use your OpenMayhem credits. Prompts, speech text, and your key pass through your RP Suite server to OpenMayhem.' : 'Replies and background scoring use your OpenMayhem credits. Chats stay saved here; prompts and your key pass through your RP Suite server to OpenMayhem for inference.'}</p>
+      {!media && <p className="mt-2">Thinking is disabled when the model supports it so short replies and scoring calls have room to answer. Stopping a reply may still incur the provider’s generation cost.</p>}
       <p className="mt-2"><a className={LINK} href="https://openmayhem.ai/models" target="_blank" rel="noopener noreferrer">Compare model prices and availability</a></p>
     </div>
   )

--- a/src/components/settings/OpenMayhemVoiceField.test.ts
+++ b/src/components/settings/OpenMayhemVoiceField.test.ts
@@ -1,0 +1,27 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { OpenMayhemVoiceField } from './OpenMayhemVoiceField'
+import type { OpenMayhemModel } from '@/lib/api/openMayhem'
+
+const model: OpenMayhemModel = { id: 'speech/model', endpoints: ['AUDIO_SPEECH'], request_contracts: [
+  { endpoint: 'AUDIO_SPEECH', attributes: { voice: { enumValues: ['default', 'new-voice'] } } },
+] }
+describe('OpenMayhem voice choices', () => {
+  it('shows newly advertised voices and never inserts a stale saved override as a choice', () => {
+    const html = renderToStaticMarkup(createElement(OpenMayhemVoiceField, { model, value: 'old-voice', onChange: () => {} }))
+    expect(html).toContain('new-voice')
+    expect(html).not.toContain('value="old-voice"')
+    expect(html).toContain('saved voice is unavailable')
+    expect(html).not.toContain('<input')
+  })
+  it('disables the voice field until an available model is known', () => {
+    const html = renderToStaticMarkup(createElement(OpenMayhemVoiceField, { value: '', onChange: () => {} }))
+    expect(html).toContain('disabled')
+    expect(html).not.toContain('<input')
+  })
+  it('allows free voice IDs only when the model does not publish an enum', () => {
+    const html = renderToStaticMarkup(createElement(OpenMayhemVoiceField, { model: { ...model, request_contracts: [{ endpoint: 'AUDIO_SPEECH', attributes: { voice: {} } }] }, value: '', onChange: () => {} }))
+    expect(html).toContain('<input')
+  })
+})

--- a/src/components/settings/OpenMayhemVoiceField.tsx
+++ b/src/components/settings/OpenMayhemVoiceField.tsx
@@ -1,0 +1,16 @@
+import { SelectField, TextField } from '@/components/ui/Field'
+import { openMayhemVoices } from '@/lib/api/openMayhemMedia'
+import type { OpenMayhemModel } from '@/lib/api/openMayhem'
+
+export function OpenMayhemVoiceField({ model, value, onChange, label = 'Voice', placeholder = 'Use model default' }: {
+  model?: OpenMayhemModel; value: string; onChange: (value: string) => void; label?: string; placeholder?: string
+}) {
+  const voices = openMayhemVoices(model)
+  if (model && !voices) return <TextField label={label} value={value} onChange={(e) => onChange(e.target.value)} placeholder={placeholder} />
+  return <SelectField label={label} value={voices?.includes(value) ? value : ''} disabled={!model}
+    onChange={(e) => onChange(e.target.value)}
+    hint={!model ? 'Choose an available speech model in Settings first.' : value && !voices?.includes(value) ? 'The saved voice is unavailable for this model. Choose a supported voice.' : 'Voices come from the selected model contract.'}>
+    <option value="">{placeholder}</option>
+    {voices?.map((voice) => <option key={voice} value={voice}>{voice}</option>)}
+  </SelectField>
+}

--- a/src/components/settings/VoiceSettings.tsx
+++ b/src/components/settings/VoiceSettings.tsx
@@ -1,4 +1,8 @@
-import { useRef, useState } from 'react'
+import { useOpenMayhemModels } from '@/lib/hooks/useOpenMayhemModels'
+import { OpenMayhemVoiceField } from './OpenMayhemVoiceField'
+import { OpenMayhemModelSelect } from './OpenMayhemModelSelect'
+import { OpenMayhemMediaKey } from './OpenMayhemMediaKey'
+import { useEffect, useRef, useState } from 'react'
 import { CheckCircle2, Loader2, XCircle } from 'lucide-react'
 import { useSettingsStore } from '@/lib/store/useSettingsStore'
 import { listKoboldSpeakers, synthesizeSpeech, TTS_PROVIDER_LABELS, type TtsProviderId } from '@/lib/voice/ttsProviders'
@@ -6,7 +10,7 @@ import { TextField } from '@/components/ui/Field'
 import { Button } from '@/components/ui/Button'
 import { Section } from '@/components/ui/Section'
 import { SettingsPage } from '@/components/ui/SettingsPage'
-import { errorMessage } from '@/lib/store/useToastStore'
+import { errorMessage, toastError } from '@/lib/store/useToastStore'
 
 const PROVIDERS = Object.keys(TTS_PROVIDER_LABELS) as TtsProviderId[]
 
@@ -17,12 +21,26 @@ export function VoiceSettings() {
   const ttsBaseUrl = useSettingsStore((s) => s.ttsBaseUrl)
   const ttsRegion = useSettingsStore((s) => s.ttsRegion)
   const ttsVoice = useSettingsStore((s) => s.ttsVoice)
+  const ttsModel = useSettingsStore((s) => s.ttsModel)
+  const openMayhemApiKey = useSettingsStore((s) => s.openMayhemApiKey)
+  const { models, loading, reload } = useOpenMayhemModels('AUDIO_SPEECH', ttsProvider === 'openmayhem')
   const setVoiceConfig = useSettingsStore((s) => s.setVoiceConfig)
   const [speakers, setSpeakers] = useState<string[]>([])
   const [loadingSpeakers, setLoadingSpeakers] = useState(false)
   const [testState, setTestState] = useState<'idle' | 'loading' | 'ok' | 'error'>('idle')
   const [testError, setTestError] = useState('')
   const testAudioRef = useRef<HTMLAudioElement | null>(null)
+
+  const testControllerRef = useRef<AbortController | null>(null)
+  const testUrlRef = useRef<string | null>(null)
+  useEffect(() => {
+    setTestState('idle')
+    return () => {
+      testControllerRef.current?.abort()
+      testAudioRef.current?.pause()
+      if (testUrlRef.current) URL.revokeObjectURL(testUrlRef.current)
+    }
+  }, [ttsProvider, ttsModel, ttsVoice, ttsApiKey, ttsBaseUrl, ttsRegion, openMayhemApiKey])
 
   const loadSpeakers = async () => {
     setLoadingSpeakers(true)
@@ -35,22 +53,37 @@ export function VoiceSettings() {
   // no quota left surfaces here instead of the first time a line is read aloud in a scene.
   const testConnection = async () => {
     testAudioRef.current?.pause()
+    if (testUrlRef.current) URL.revokeObjectURL(testUrlRef.current)
+    const controller = new AbortController()
+    testControllerRef.current = controller
     setTestState('loading')
     setTestError('')
     try {
       const blob = await synthesizeSpeech(
-        { provider: ttsProvider, apiKey: ttsApiKey, baseUrl: ttsBaseUrl, region: ttsRegion, voice: ttsVoice },
+        { provider: ttsProvider, apiKey: ttsProvider === 'openmayhem' ? openMayhemApiKey : ttsApiKey, model: ttsModel, baseUrl: ttsBaseUrl, region: ttsRegion, voice: ttsVoice },
         'Testing, one two three.',
         baseUrl,
+        controller.signal,
       )
+      controller.signal.throwIfAborted()
       const url = URL.createObjectURL(blob)
+      testUrlRef.current = url
       const audio = new Audio(url)
       testAudioRef.current = audio
       audio.onended = () => URL.revokeObjectURL(url)
-      audio.onerror = () => URL.revokeObjectURL(url)
-      await audio.play().catch(() => {})
+      audio.onerror = () => {
+        URL.revokeObjectURL(url)
+        setTestError('The browser could not play the generated audio.')
+        setTestState('error')
+      }
+      await audio.play()
       setTestState('ok')
     } catch (e) {
+      if (controller.signal.aborted) {
+        if (!(e instanceof DOMException && e.name === 'AbortError')) toastError(errorMessage(e))
+        return
+      }
+      if (testUrlRef.current) URL.revokeObjectURL(testUrlRef.current)
       setTestState('error')
       setTestError(errorMessage(e))
     }
@@ -60,7 +93,7 @@ export function VoiceSettings() {
     <SettingsPage>
       <Section
         title="Voice (text-to-speech)"
-        description="Read a character's lines aloud from Visual Novel mode. Keys are stored only in this browser and sent directly to the provider you pick. Never through any other server."
+        description="Read a character's lines aloud from Visual Novel mode. Keys are stored in this browser. OpenMayhem uses RP Suite's local relay; other providers are contacted directly."
       >
           <label className="mb-3 block">
             <span className="mb-1 block text-xs font-medium text-text-muted">Provider</span>
@@ -79,6 +112,15 @@ export function VoiceSettings() {
               ))}
             </select>
           </label>
+
+          {ttsProvider === 'openmayhem' && <>
+            <OpenMayhemMediaKey />
+            <OpenMayhemModelSelect kind="speech" models={models?.map((m) => m.id) ?? null} loading={loading} value={ttsModel}
+              onChange={(model) => setVoiceConfig({ ttsModel: model, ttsVoice: '' })} />
+            <Button onClick={reload} disabled={loading}>Refresh models</Button>
+            <OpenMayhemVoiceField model={models?.find((m) => m.id === ttsModel)} value={ttsVoice} onChange={(voice) => setVoiceConfig({ ttsVoice: voice })} />
+            <p className="my-3 text-xs text-text-muted">Testing and reading lines aloud generate billed speech jobs. Visual Novel mode uses this model and voice; character voice overrides must be supported by this model. Stop requests cancellation; work already done may still be billed.</p>
+          </>}
 
           {ttsProvider === 'koboldcpp' && (
             <>
@@ -172,10 +214,11 @@ export function VoiceSettings() {
 
           {ttsProvider !== 'alibaba' && (
             <div className="mt-3 flex items-center gap-2.5">
-              <Button onClick={testConnection} disabled={testState === 'loading'} className="flex items-center gap-1.5">
+              <Button onClick={testConnection} disabled={testState === 'loading' || ttsProvider === 'openmayhem' && (!openMayhemApiKey.trim() || !models?.some((m) => m.id === ttsModel))} className="flex items-center gap-1.5">
                 {testState === 'loading' ? <Loader2 size={14} strokeWidth={2} className="animate-spin" /> : null}
                 {testState === 'loading' ? 'Testing…' : 'Test connection'}
               </Button>
+              {testState === 'loading' && <Button onClick={() => { testControllerRef.current?.abort(); setTestState('idle') }}>Stop test</Button>}
               {testState === 'ok' && (
                 <span className="flex items-center gap-1 text-xs text-success">
                   <CheckCircle2 size={14} strokeWidth={2} />

--- a/src/components/ui/GenerateImageButton.tsx
+++ b/src/components/ui/GenerateImageButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Sparkles } from 'lucide-react'
 import { useSettingsStore } from '@/lib/store/useSettingsStore'
 import { createImageBackend } from '@/lib/api/createImageBackend'
@@ -7,15 +7,6 @@ import { Button } from '@/components/ui/Button'
 import { TextAreaField } from '@/components/ui/Field'
 import { IconButton } from '@/components/ui/IconButton'
 
-/**
- * Section 11's "generate directly into a specific slot" — wired into every existing image slot
- * (character avatar, per-expression sprites, world backgrounds, gallery CGs), each seeded with a
- * prompt built from real context (the character/world's own description, the specific expression
- * or scene it's for) rather than one generic blank box. None of the four backends this calls into
- * have been run against a real server (NovelAI image got one real, partial check — see ROADMAP.md
- * #124/#125); a failure here is at least as likely to be a wrong assumption in this app's own
- * client as a problem with the server it's pointed at.
- */
 export function GenerateImageButton({
   onGenerated,
   initialPrompt = '',
@@ -33,18 +24,23 @@ export function GenerateImageButton({
   const [open, setOpen] = useState(false)
   const [prompt, setPrompt] = useState(initialPrompt)
   const [busy, setBusy] = useState(false)
+  const controllerRef = useRef<AbortController | null>(null)
 
+  const openMayhemApiKey = useSettingsStore((s) => s.openMayhemApiKey)
   const imageBackend = useSettingsStore((s) => s.imageBackend)
   const imageBackendBaseUrl = useSettingsStore((s) => s.imageBackendBaseUrl)
   const imageBackendUsername = useSettingsStore((s) => s.imageBackendUsername)
   const imageBackendPassword = useSettingsStore((s) => s.imageBackendPassword)
   const imageBackendModel = useSettingsStore((s) => s.imageBackendModel)
+  useEffect(() => () => controllerRef.current?.abort(), [imageBackend, imageBackendModel, imageBackendBaseUrl, openMayhemApiKey, imageBackendUsername, imageBackendPassword])
 
   const generate = async () => {
     if (!prompt.trim() || busy) return
     setBusy(true)
+    const controller = new AbortController()
+    controllerRef.current = controller
     try {
-      const backend = createImageBackend({
+      const backend = createImageBackend({ openMayhemApiKey,
         imageBackend,
         imageBackendBaseUrl,
         imageBackendUsername,
@@ -58,20 +54,22 @@ export function GenerateImageButton({
         steps: 28,
         cfgScale: 7,
         model: imageBackendModel || undefined,
-      })
+      }, controller.signal)
+      controller.signal.throwIfAborted()
       if (!result.base64) throw new Error('The backend returned no image data.')
-      onGenerated(`data:image/png;base64,${result.base64}`)
+      onGenerated(`data:${result.mimeType || 'image/png'};base64,${result.base64}`)
       setOpen(false)
     } catch (e) {
-      toastError(`Image generation failed: ${errorMessage(e)}`)
+      if (!(e instanceof DOMException && e.name === 'AbortError')) toastError(`Image generation failed: ${errorMessage(e)}`)
     } finally {
+      controllerRef.current = null
       setBusy(false)
     }
   }
 
   if (!open) {
     return (
-      <IconButton icon={Sparkles} title={label} onClick={() => setOpen(true)} size={13} boxSize={26} />
+      <IconButton icon={Sparkles} title={label} onClick={() => { setPrompt(initialPrompt); setOpen(true) }} size={13} boxSize={26} />
     )
   }
 
@@ -86,8 +84,8 @@ export function GenerateImageButton({
         hint={`Sends to ${imageBackend}. See Settings → Images.`}
       />
       <div className="mt-2 flex justify-end gap-2">
-        <Button variant="ghost" onClick={() => setOpen(false)} disabled={busy}>
-          Cancel
+        <Button variant="ghost" onClick={() => { controllerRef.current?.abort(); setOpen(false) }}>
+          {busy ? 'Stop' : 'Cancel'}
         </Button>
         <Button variant="primary" onClick={generate} disabled={busy || !prompt.trim()}>
           {busy ? 'Generating…' : 'Generate'}

--- a/src/lib/api/createImageBackend.ts
+++ b/src/lib/api/createImageBackend.ts
@@ -2,9 +2,11 @@ import { A1111Client } from './a1111Image'
 import { ComfyUIClient } from './comfyuiImage'
 import { SwarmUIClient } from './swarmuiImage'
 import { NovelAIImageClient } from './novelaiImage'
+import { OpenMayhemImageClient } from './openMayhemMedia'
 import type { ImageBackend, ImageBackendId } from './imageBackend'
 
 export interface ImageBackendSettings {
+  openMayhemApiKey?: string
   imageBackend: ImageBackendId
   /** a1111 / comfyui / swarmui only. */
   imageBackendBaseUrl: string
@@ -18,6 +20,8 @@ export interface ImageBackendSettings {
 /** Section 11's image-backend factory — the `createChatBackend` pattern applied to image generation. */
 export function createImageBackend(settings: ImageBackendSettings): ImageBackend {
   switch (settings.imageBackend) {
+    case 'openmayhem':
+      return new OpenMayhemImageClient(settings.openMayhemApiKey || '', settings.imageBackendModel)
     case 'comfyui':
       return new ComfyUIClient(settings.imageBackendBaseUrl)
     case 'swarmui':

--- a/src/lib/api/imageBackend.ts
+++ b/src/lib/api/imageBackend.ts
@@ -23,6 +23,7 @@ export interface ImageGenerateParams {
 export interface ImageGenerateResult {
   /** Base64-encoded image bytes, no `data:` prefix — callers wrap it into a data URL themselves (matches how `decodeImageDataUrl` on the server already expects one). */
   base64: string
+  mimeType?: string
   /** The seed actually used, when the backend reports it — useful since `params.seed` is often left unset for a random one. */
   seed?: number
 }
@@ -32,9 +33,10 @@ export interface ImageBackend {
   listModels(): Promise<string[]>
 }
 
-export type ImageBackendId = 'a1111' | 'comfyui' | 'swarmui' | 'novelai-image'
+export type ImageBackendId = 'a1111' | 'comfyui' | 'swarmui' | 'novelai-image' | 'openmayhem'
 
 export const IMAGE_BACKEND_LABELS: Record<ImageBackendId, string> = {
+  openmayhem: 'OpenMayhem (hosted)',
   a1111: 'Automatic1111 / Forge (local)',
   comfyui: 'ComfyUI (local)',
   swarmui: 'SwarmUI (local)',

--- a/src/lib/api/openMayhem.test.ts
+++ b/src/lib/api/openMayhem.test.ts
@@ -43,7 +43,7 @@ describe('OpenMayhem integration', () => {
       { ...model, id: 'tool-only', request_contracts: [{ ...model.request_contracts![0], required: ['model', 'messages', 'tools'] }] },
     ] })))
     expect(await listOpenAiModels(OPENMAYHEM_BASE_URL, 'private-key')).toEqual(['example/chat'])
-    expect(fetchMock.mock.calls[0][0]).toBe('/api/openmayhem/models')
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/openmayhem/models?endpoint_family=CHAT')
     expect(fetchMock.mock.calls[0][1].headers).toBeUndefined()
     expect(await fetchOpenAiModelContext(OPENMAYHEM_BASE_URL, model.id)).toBe(32768)
   })

--- a/src/lib/api/openMayhem.ts
+++ b/src/lib/api/openMayhem.ts
@@ -7,7 +7,8 @@ export function isOpenMayhem(baseUrl: string): boolean {
   return baseUrl.trim().replace(/\/+$/, '') === OPENMAYHEM_BASE_URL
 }
 
-type Attribute = { enumValues?: unknown[]; minimum?: number; maximum?: number }
+export type Attribute = { enumValues?: unknown[]; minimum?: number; maximum?: number; default?: unknown; multipleOf?: number; maxLength?: number; minLength?: number }
+export type OpenMayhemEndpoint = 'CHAT' | 'IMAGES' | 'AUDIO_SPEECH'
 type Contract = { endpoint: string; required?: string[]; attributes: Record<string, Attribute> }
 export interface OpenMayhemModel {
   id: string
@@ -35,19 +36,69 @@ export function hasAvailableOpenMayhemProvider(model: OpenMayhemModel): boolean 
     && model.providers_available > 0
 }
 
-let catalog: { until: number; promise: Promise<OpenMayhemModel[]> } | undefined
-export function loadOpenMayhemModels(refresh = false): Promise<OpenMayhemModel[]> {
+const catalogs = new Map<OpenMayhemEndpoint, { until: number; promise: Promise<OpenMayhemModel[]> }>()
+export function loadOpenMayhemModels(refresh = false, endpoint: OpenMayhemEndpoint = 'CHAT'): Promise<OpenMayhemModel[]> {
+  const catalog = catalogs.get(endpoint)
   if (!refresh && catalog && catalog.until > Date.now()) return catalog.promise
-  const promise = fetch(`${OPENMAYHEM_PROXY}/models`, { signal: AbortSignal.timeout(10000) })
-    .then(async (res) => {
+  const promise = (async () => {
+    const models = new Map<string, OpenMayhemModel>()
+    const seen = new Set<string>()
+    let cursor: string | undefined
+    do {
+      const query = new URLSearchParams({ endpoint_family: endpoint })
+      if (cursor) query.set('cursor', cursor)
+      const res = await fetch(`${OPENMAYHEM_PROXY}/models?${query}`, { signal: AbortSignal.timeout(10000) })
       if (!res.ok) throw new Error('OpenMayhem model catalog is unavailable. Try again shortly.')
-      const body = await res.json() as { data?: OpenMayhemModel[] }
+      const body = await res.json() as { data?: OpenMayhemModel[]; next_cursor?: string | null }
       if (!Array.isArray(body.data)) throw new Error('OpenMayhem returned an invalid model catalog.')
-      return body.data.filter(isOpenMayhemChatModel)
-    })
-  catalog = { until: Date.now() + 60000, promise }
-  void promise.catch(() => { if (catalog?.promise === promise) catalog = undefined })
+      for (const model of body.data) if (isCompatibleOpenMayhemModel(model, endpoint)) models.set(model.id, model)
+      cursor = body.next_cursor || undefined
+      if (cursor && (typeof cursor !== 'string' || seen.has(cursor))) throw new Error('OpenMayhem returned an invalid catalog cursor.')
+      if (cursor) seen.add(cursor)
+    } while (cursor)
+    return [...models.values()]
+  })()
+  catalogs.set(endpoint, { until: Date.now() + 60000, promise })
+  void promise.catch(() => { if (catalogs.get(endpoint)?.promise === promise) catalogs.delete(endpoint) })
   return promise
+}
+
+export function isCompatibleOpenMayhemModel(model: OpenMayhemModel, endpoint: OpenMayhemEndpoint): boolean {
+  if (endpoint === 'CHAT') return isOpenMayhemChatModel(model)
+  const supplied = endpoint === 'IMAGES'
+    ? ['model', 'prompt', 'size', 'width', 'height', 'n', 'steps', 'cfg_scale', 'seed', 'negative_prompt']
+    : ['model', 'input', 'voice', 'response_format']
+  const contracts = model.request_contracts?.filter((c) => c.endpoint === endpoint)
+  const compatible = !!model.endpoints?.includes(endpoint) && !!contracts?.length && contracts.every((c) =>
+    !!c.attributes && (c.required ?? []).every((key) => supplied.includes(key)),
+  )
+  if (!compatible) return false
+  if (endpoint === 'AUDIO_SPEECH') {
+    const voices = openMayhemAttribute(model, endpoint, 'voice')?.enumValues
+    const formats = openMayhemAttribute(model, endpoint, 'response_format')?.enumValues
+    return (!voices || voices.length > 0) && (!formats || formats.some((f) => f === 'wav' || f === 'mp3'))
+  }
+  return true
+}
+
+/** Intersect runtime contracts: a request may route to any available implementation. */
+export function openMayhemAttribute(model: OpenMayhemModel, endpoint: OpenMayhemEndpoint, key: string): Attribute | undefined {
+  const attrs = model.request_contracts?.filter((c) => c.endpoint === endpoint).map((c) => c.attributes[key])
+  if (!attrs?.length || attrs.some((a) => !a)) return undefined
+  const enums = attrs.filter((a) => a.enumValues).map((a) => a.enumValues!)
+  const values = enums.length ? enums[0].filter((value) => enums.every((e) => e.includes(value))) : undefined
+  return {
+    enumValues: values,
+    default: attrs.every((a) => a.default === attrs[0].default) ? attrs[0].default : undefined,
+    minimum: Math.max(...attrs.map((a) => a.minimum ?? -Infinity)),
+    maximum: Math.min(...attrs.map((a) => a.maximum ?? Infinity)),
+    maxLength: Math.min(...attrs.map((a) => a.maxLength ?? Infinity)),
+    minLength: Math.max(...attrs.map((a) => a.minLength ?? 0)),
+    multipleOf: attrs.some((a) => a.multipleOf !== undefined) ? attrs.filter((a) => a.multipleOf !== undefined).map((a) => a.multipleOf!).reduce((multiple, next) => {
+      const gcd = (x: number, y: number): number => y ? gcd(y, x % y) : x
+      return multiple * next / gcd(multiple, next)
+    }) : undefined,
+  }
 }
 
 /** Keep short judge calls useful: disable thinking when the model explicitly supports it.

--- a/src/lib/api/openMayhemMedia.test.ts
+++ b/src/lib/api/openMayhemMedia.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { availableMediaModel, generateOpenMayhemMedia, openMayhemImageBody, openMayhemVoices, speakOpenMayhem } from './openMayhemMedia'
+import { loadOpenMayhemModels, type OpenMayhemModel } from './openMayhem'
+import { createImageBackend } from './createImageBackend'
+
+const image: OpenMayhemModel = { id: 'image/model', endpoints: ['IMAGES'], providers_available: 1, request_contracts: [
+  { endpoint: 'IMAGES', required: ['model', 'prompt'], attributes: {
+    prompt: { maxLength: 20000 }, width: { minimum: 576, maximum: 2048, multipleOf: 16 }, height: { minimum: 576, maximum: 2048, multipleOf: 16 },
+    steps: { default: 9, minimum: 7, maximum: 9 }, cfg_scale: { default: 0 }, n: { maximum: 4, minimum: 1 }, seed: { minimum: 0, maximum: 4294967295 },
+  } },
+] }
+const speech: OpenMayhemModel = { id: 'speech/model', endpoints: ['AUDIO_SPEECH'], providers_available: 1, request_contracts: [
+  { endpoint: 'AUDIO_SPEECH', required: ['model', 'input', 'voice'], attributes: { input: { maxLength: 10 }, voice: { default: 'default', enumValues: ['default'] }, response_format: { enumValues: ['wav'] } } },
+] }
+const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
+let fetchMock: ReturnType<typeof vi.fn>
+beforeEach(() => { fetchMock = vi.fn(); vi.stubGlobal('fetch', fetchMock) })
+afterEach(() => { vi.unstubAllGlobals(); vi.useRealTimers() })
+
+describe('OpenMayhem media catalog and contracts', () => {
+  it('loads every page, discovers new models, deduplicates IDs, and keeps endpoint caches separate', async () => {
+    fetchMock.mockResolvedValueOnce(json({ data: [image], next_cursor: 'page/+2' }))
+      .mockResolvedValueOnce(json({ data: [image, { ...image, id: 'new/image' }] }))
+    expect((await loadOpenMayhemModels(true, 'IMAGES')).map((m) => m.id)).toEqual(['image/model', 'new/image'])
+    expect(fetchMock.mock.calls[1][0]).toBe('/api/openmayhem/models?endpoint_family=IMAGES&cursor=page%2F%2B2')
+    expect(fetchMock.mock.calls.every(([, init]) => !init.headers)).toBe(true)
+    fetchMock.mockResolvedValueOnce(json({ data: [speech] }))
+    expect((await loadOpenMayhemModels(true, 'AUDIO_SPEECH'))[0].id).toBe('speech/model')
+    expect((await loadOpenMayhemModels(false, 'IMAGES'))).toHaveLength(2)
+  })
+  it('fails a repeated cursor instead of showing a partially synced list', async () => {
+    fetchMock.mockImplementation(() => json({ data: [image], next_cursor: 'loop' }))
+    await expect(loadOpenMayhemModels(true, 'IMAGES')).rejects.toThrow('cursor')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+  it('rejects offline, stale, and incompatible models before submitting a billed job', async () => {
+    for (const model of [{ ...image, providers_available: 0 }, { ...image, availability_stale: true },
+      { ...image, request_contracts: [{ ...image.request_contracts![0], required: ['model', 'prompt', 'input_reference'] }] }]) {
+      fetchMock.mockResolvedValueOnce(json({ data: [model] }))
+      await expect(availableMediaModel('IMAGES', image.id)).rejects.toThrow('no available compatible provider')
+    }
+    expect(fetchMock.mock.calls.every(([, init]) => !init.method)).toBe(true)
+  })
+  it('uses hosted defaults and supported dimensions across portrait, background and batch slots', () => {
+    const body = openMayhemImageBody(image, { prompt: 'lighthouse', width: 768, height: 512, steps: 28, cfgScale: 7, seed: 42 })
+    expect(body).toEqual({ model: image.id, prompt: 'lighthouse', width: 864, height: 576, steps: 9, cfg_scale: 0, n: 1, seed: 42 })
+    expect(() => openMayhemImageBody(image, { prompt: 'x', width: 832, height: 1216, steps: 28, cfgScale: 7, negativePrompt: 'text' })).toThrow('negative prompt')
+  })
+  it('derives voices from contracts and rejects stale voices / too-long text without inference', async () => {
+    expect(openMayhemVoices(speech)).toEqual(['default'])
+    fetchMock.mockImplementation(() => json({ data: [speech] }))
+    await expect(speakOpenMayhem('key', speech.id, 'Hello', 'alloy')).rejects.toThrow('voice')
+    await expect(speakOpenMayhem('key', speech.id, 'long text beyond limit', '')).rejects.toThrow('text length')
+    expect(fetchMock.mock.calls.every(([, init]) => !init.method)).toBe(true)
+  })
+  it('preserves fractional guidance defaults on future image models', () => {
+    const fractional = { ...image, request_contracts: [{ ...image.request_contracts![0], attributes: {
+      ...image.request_contracts![0].attributes, cfg_scale: { default: 7.5, minimum: 0, maximum: 20 },
+    } }] }
+    expect(openMayhemImageBody(fractional, { prompt: 'x', width: 832, height: 1216, steps: 28, cfgScale: 7 }).cfg_scale).toBe(7.5)
+  })
+})
+
+describe('OpenMayhem async media lifecycle', () => {
+  it('submits once, polls and downloads only a fixed owned artifact path, preserving MIME', async () => {
+    vi.useFakeTimers()
+    fetchMock.mockResolvedValueOnce(json({ id: 'job_1', status: 'running', polling_url: 'https://untrusted.test' }))
+      .mockResolvedValueOnce(json({ id: 'job_1', status: 'completed', artifacts: [{ id: 'artifact_1', contentType: 'image/webp', url: 'https://untrusted.test' }] }))
+      .mockResolvedValueOnce(new Response('image bytes', { headers: { 'Content-Type': 'image/webp' } }))
+    const pending = generateOpenMayhemMedia('IMAGES', ' key ', { model: image.id })
+    await vi.advanceTimersByTimeAsync(1500)
+    const blob = await pending
+    expect(blob.type).toBe('image/webp')
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual(['/api/openmayhem/images/generations', '/api/openmayhem/jobs/job_1', '/api/openmayhem/artifacts/artifact_1'])
+    expect(fetchMock.mock.calls.filter(([, init]) => init.method === 'POST')).toHaveLength(1)
+    expect(fetchMock.mock.calls.every(([, init]) => init.headers.Authorization === 'Bearer key')).toBe(true)
+  })
+  it('recovers the ID and cancels when Stop arrives during submission', async () => {
+    const controller = new AbortController()
+    fetchMock.mockImplementationOnce(async () => { controller.abort(); return json({ id: 'job_1', status: 'running' }) })
+      .mockResolvedValueOnce(json({ status: 'cancelled' }))
+    await expect(generateOpenMayhemMedia('IMAGES', 'key', {}, controller.signal)).rejects.toMatchObject({ name: 'AbortError' })
+    expect(fetchMock.mock.calls[1]).toEqual(['/api/openmayhem/jobs/job_1', expect.objectContaining({ method: 'DELETE' })])
+  })
+  it('surfaces failed cancellation rather than promising the job stopped', async () => {
+    const controller = new AbortController()
+    fetchMock.mockImplementationOnce(async () => { controller.abort(); return json({ id: 'job_1', status: 'running' }) })
+      .mockResolvedValueOnce(json({ error: { message: 'Unavailable' } }, 503))
+    await expect(generateOpenMayhemMedia('IMAGES', 'key', {}, controller.signal)).rejects.toThrow('Could not confirm cancellation')
+  })
+  it('does not retry auth, credit, capacity errors or terminal failures', async () => {
+    for (const status of [401, 402, 429, 503]) {
+      fetchMock.mockResolvedValueOnce(json({ error: { message: 'No capacity or credit' } }, status))
+      await expect(generateOpenMayhemMedia('AUDIO_SPEECH', 'key', {})).rejects.toThrow(`(${status})`)
+    }
+    fetchMock.mockResolvedValueOnce(json({ id: 'job_1', status: 'failed', error: 'Provider failed after partial work' }))
+    await expect(generateOpenMayhemMedia('IMAGES', 'key', {})).rejects.toThrow('Provider failed')
+    expect(fetchMock).toHaveBeenCalledTimes(5)
+  })
+  it('does not retry a submission whose outcome is unknown after a network failure', async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError('Connection reset'))
+    await expect(generateOpenMayhemMedia('IMAGES', 'key', {})).rejects.toThrow('submission status is unknown')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+  it('cancels an in-progress job when its polling request is aborted', async () => {
+    vi.useFakeTimers()
+    const controller = new AbortController()
+    fetchMock.mockResolvedValueOnce(json({ id: 'job_1', status: 'running' }))
+      .mockImplementationOnce(async () => { controller.abort(); throw controller.signal.reason })
+      .mockResolvedValueOnce(json({ status: 'cancelled' }))
+    const result = generateOpenMayhemMedia('IMAGES', 'key', {}, controller.signal).catch((e: Error) => e)
+    await vi.advanceTimersByTimeAsync(1500)
+    expect(await result).toMatchObject({ name: 'AbortError' })
+    expect(fetchMock.mock.calls[2][1].method).toBe('DELETE')
+  })
+  it('rejects a completed job with missing/wrong media', async () => {
+    fetchMock.mockResolvedValueOnce(json({ id: 'job_1', status: 'completed', artifacts: [] }))
+    await expect(generateOpenMayhemMedia('IMAGES', 'key', {})).rejects.toThrow('without a usable media artifact')
+    fetchMock.mockResolvedValueOnce(json({ id: 'job_2', status: 'completed', artifacts: [{ id: 'a', contentType: 'audio/wav' }] }))
+      .mockResolvedValueOnce(new Response('<html>error</html>', { headers: { 'Content-Type': 'text/html' } }))
+    await expect(generateOpenMayhemMedia('AUDIO_SPEECH', 'key', {})).rejects.toThrow('invalid media data')
+  })
+  it('uses the dedicated key in the shared image factory and defaults the speech voice', async () => {
+    fetchMock.mockResolvedValueOnce(json({ data: [image] }))
+      .mockResolvedValueOnce(json({ id: 'job', status: 'completed', artifacts: [{ id: 'a', contentType: 'image/png' }] }))
+      .mockResolvedValueOnce(new Response('png', { headers: { 'Content-Type': 'image/png' } }))
+    const backend = createImageBackend({ imageBackend: 'openmayhem', imageBackendModel: image.id, imageBackendBaseUrl: 'https://wrong.test', imageBackendUsername: 'wrong-key', imageBackendPassword: '', openMayhemApiKey: 'media-key' })
+    const result = await backend.generateImage({ prompt: 'x', width: 832, height: 1216, steps: 28, cfgScale: 7 })
+    expect(result.mimeType).toBe('image/png')
+    expect(atob(result.base64)).toBe('png')
+    expect(fetchMock.mock.calls[1][1].headers.Authorization).toBe('Bearer media-key')
+    fetchMock.mockResolvedValueOnce(json({ data: [speech] }))
+      .mockResolvedValueOnce(json({ id: 'job', status: 'completed', artifacts: [{ id: 'a', contentType: 'audio/wav' }] }))
+      .mockResolvedValueOnce(new Response('wav', { headers: { 'Content-Type': 'audio/wav' } }))
+    await speakOpenMayhem('media-key', speech.id, 'Hello', '')
+    expect(JSON.parse(fetchMock.mock.calls[4][1].body)).toEqual({ model: speech.id, input: 'Hello', voice: 'default', response_format: 'wav' })
+  })
+})

--- a/src/lib/api/openMayhemMedia.ts
+++ b/src/lib/api/openMayhemMedia.ts
@@ -1,0 +1,171 @@
+import { hasAvailableOpenMayhemProvider, loadOpenMayhemModels, openMayhemAttribute, OPENMAYHEM_PROXY, type Attribute, type OpenMayhemModel } from './openMayhem'
+import type { ImageBackend, ImageGenerateParams, ImageGenerateResult } from './imageBackend'
+
+type Endpoint = 'IMAGES' | 'AUDIO_SPEECH'
+type Job = { id: string; status: string; error?: string | { message?: string }; artifacts?: { id: string; contentType?: string; content_type?: string }[] }
+const resourceId = (id: string) => {
+  if (!/^[a-zA-Z0-9_-]{1,200}$/.test(id)) throw new Error('OpenMayhem returned an invalid resource ID.')
+  return id
+}
+async function checkResponse(res: Response): Promise<Response> {
+  if (!res.ok) {
+    const body = await res.json().catch(() => null) as { error?: { message?: string }; message?: string } | null
+    throw new Error(`OpenMayhem (${res.status}): ${body?.error?.message || body?.message || 'Request failed.'}`)
+  }
+  return res
+}
+function waitForPoll(signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    signal.throwIfAborted()
+    const abort = () => { clearTimeout(timer); reject(signal.reason) }
+    const timer = setTimeout(() => { signal.removeEventListener('abort', abort); resolve() }, 1500)
+    signal.addEventListener('abort', abort, { once: true })
+  })
+}
+
+/** Submit once, poll without resubmitting, then retrieve the owned artifact through our relay. */
+export async function generateOpenMayhemMedia(endpoint: Endpoint, apiKey: string, body: Record<string, unknown>, signal?: AbortSignal): Promise<Blob> {
+  if (!apiKey.trim()) throw new Error('Enter your OpenMayhem media API key in Settings first.')
+  signal?.throwIfAborted()
+  const headers = { Authorization: `Bearer ${apiKey.trim()}` }
+  const lifetime = AbortSignal.any([AbortSignal.timeout(300000), ...(signal ? [signal] : [])])
+  let jobId: string | undefined
+  let terminal = false
+  try {
+    // Keep submission alive long enough to recover its ID even if the user presses Stop.
+    // Once it arrives, the aborted lifetime triggers DELETE below instead of leaving an orphan job.
+    let job: Job = await (await checkResponse(await fetch(`${OPENMAYHEM_PROXY}/${endpoint === 'IMAGES' ? 'images/generations' : 'audio/speech'}`, {
+      method: 'POST', headers: { ...headers, 'Content-Type': 'application/json' }, body: JSON.stringify(body), signal: AbortSignal.timeout(30000),
+    }))).json() as Job
+    jobId = resourceId(job.id)
+    for (;;) {
+      lifetime.throwIfAborted()
+      if (job.status === 'completed') { terminal = true; break }
+      if (['failed', 'cancelled', 'expired'].includes(job.status)) {
+        terminal = true
+        throw new Error(typeof job.error === 'string' ? job.error : job.error?.message || `OpenMayhem job ${job.status}.`)
+      }
+      if (!['submitted', 'queued', 'pending', 'running', 'reconciling'].includes(job.status)) throw new Error('OpenMayhem returned an unknown job status.')
+      await waitForPoll(lifetime)
+      job = await (await checkResponse(await fetch(`${OPENMAYHEM_PROXY}/jobs/${jobId}`, { headers, signal: AbortSignal.any([lifetime, AbortSignal.timeout(30000)]) }))).json() as Job
+    }
+    const kind = endpoint === 'IMAGES' ? 'image/' : 'audio/'
+    const artifact = job.artifacts?.find((a) => (a.contentType || a.content_type)?.startsWith(kind))
+    if (!artifact) throw new Error('OpenMayhem completed without a usable media artifact.')
+    const res = await checkResponse(await fetch(`${OPENMAYHEM_PROXY}/artifacts/${resourceId(artifact.id)}`, { headers, signal: lifetime }))
+    const blob = await res.blob()
+    if (!blob.size || !blob.type.startsWith(kind)) throw new Error('OpenMayhem returned invalid media data.')
+    return blob
+  } catch (error) {
+    if (!jobId && (error instanceof TypeError || error instanceof DOMException && error.name === 'TimeoutError')) {
+      throw new Error('OpenMayhem submission status is unknown after a connection failure. Check your OpenMayhem dashboard before retrying; a job may already be running.')
+    }
+    if (jobId && !terminal) {
+      try {
+        await checkResponse(await fetch(`${OPENMAYHEM_PROXY}/jobs/${jobId}`, { method: 'DELETE', headers, signal: AbortSignal.timeout(10000) }))
+      } catch {
+        throw new Error(`Could not confirm cancellation of OpenMayhem job ${jobId}. Check your OpenMayhem dashboard before retrying; work may still be billed.`)
+      }
+    }
+    throw error
+  }
+}
+
+export async function availableMediaModel(endpoint: Endpoint, id: string): Promise<OpenMayhemModel> {
+  if (!id) throw new Error(`Choose an OpenMayhem ${endpoint === 'IMAGES' ? 'image' : 'speech'} model in Settings first.`)
+  const model = (await loadOpenMayhemModels(true, endpoint)).find((m) => m.id === id && hasAvailableOpenMayhemProvider(m))
+  if (!model) throw new Error('This OpenMayhem model has no available compatible provider. Refresh Settings and choose an available model.')
+  return model
+}
+
+function validate(value: unknown, attr: Attribute, key: string): void {
+  if (attr.enumValues && !attr.enumValues.includes(value)
+    || typeof value === 'number' && (!Number.isFinite(value) || value < (attr.minimum ?? -Infinity) || value > (attr.maximum ?? Infinity)
+      || attr.multipleOf !== undefined && Math.abs(value / attr.multipleOf - Math.round(value / attr.multipleOf)) > 1e-7)
+    || typeof value === 'string' && (value.length > (attr.maxLength ?? Infinity) || value.length < (attr.minLength ?? 0))) {
+    throw new Error(`The selected OpenMayhem model does not support this ${key}. Check the model settings.`)
+  }
+}
+
+function requiredFields(model: OpenMayhemModel, endpoint: Endpoint, body: Record<string, unknown>) {
+  for (const c of model.request_contracts!.filter((c) => c.endpoint === endpoint)) {
+    for (const key of c.required ?? []) if (body[key] === undefined) throw new Error(`This OpenMayhem model requires ${key}. Choose a different model.`)
+  }
+}
+
+export function openMayhemVoices(model?: OpenMayhemModel): string[] | undefined {
+  return model ? openMayhemAttribute(model, 'AUDIO_SPEECH', 'voice')?.enumValues?.filter((v): v is string => typeof v === 'string') : undefined
+}
+
+export async function speakOpenMayhem(apiKey: string, modelId: string, input: string, voice: string, signal?: AbortSignal): Promise<Blob> {
+  const model = await availableMediaModel('AUDIO_SPEECH', modelId)
+  const body: Record<string, unknown> = { model: model.id, input }
+  const inputAttr = openMayhemAttribute(model, 'AUDIO_SPEECH', 'input')
+  if (inputAttr) validate(input, inputAttr, 'text length')
+  const attr = openMayhemAttribute(model, 'AUDIO_SPEECH', 'voice')
+  const chosen = voice || attr?.default || openMayhemVoices(model)?.[0]
+  if (chosen && attr) { validate(chosen, attr, 'voice'); body.voice = chosen }
+  else if (voice) throw new Error('This OpenMayhem speech model does not support voice selection.')
+  const format = openMayhemAttribute(model, 'AUDIO_SPEECH', 'response_format')
+  if (format) {
+    const playable = ['wav', 'mp3'].find((f) => !format.enumValues || format.enumValues.includes(f))
+    if (!playable) throw new Error('This speech model has no browser-playable audio format.')
+    body.response_format = playable
+  }
+  requiredFields(model, 'AUDIO_SPEECH', body)
+  return generateOpenMayhemMedia('AUDIO_SPEECH', apiKey, body, signal)
+}
+
+/** Slots supply their aspect ratio. Hosted generation uses the model's own sampling defaults. */
+export function openMayhemImageBody(model: OpenMayhemModel, params: ImageGenerateParams): Record<string, unknown> {
+  const body: Record<string, unknown> = { model: model.id, prompt: params.prompt }
+  const attr = (key: string) => openMayhemAttribute(model, 'IMAGES', key)
+  if (params.prompt.length > 20000) throw new Error('OpenMayhem image prompts are limited to 20,000 characters.')
+  if (attr('prompt')) validate(params.prompt, attr('prompt')!, 'prompt')
+  const fit = (value: number, a?: Attribute) => {
+    const multiple = a?.multipleOf || 1
+    const min = Math.ceil((a?.minimum ?? 1) / multiple) * multiple
+    const max = Math.floor((a?.maximum ?? 4096) / multiple) * multiple
+    return Math.max(min, Math.min(max, Math.round(value / multiple) * multiple))
+  }
+  if (attr('width') && attr('height')) {
+    const minScale = Math.max((attr('width')!.minimum ?? 1) / params.width, (attr('height')!.minimum ?? 1) / params.height)
+    const maxScale = Math.min((attr('width')!.maximum ?? 4096) / params.width, (attr('height')!.maximum ?? 4096) / params.height)
+    const scale = Math.min(maxScale, Math.max(1, minScale))
+    body.width = fit(params.width * scale, attr('width'))
+    body.height = fit(params.height * scale, attr('height'))
+  } else if (attr('size')) {
+    const sizes = attr('size')!.enumValues?.filter((s): s is string => typeof s === 'string' && /^\d+x\d+$/.test(s))
+    body.size = sizes?.length ? sizes.slice().sort((a, b) => {
+      const distance = (size: string) => { const [w, h] = size.split('x').map(Number); return Math.abs(w / h - params.width / params.height) }
+      return distance(a) - distance(b)
+    })[0] : `${params.width}x${params.height}`
+  }
+  for (const [key, fallback] of [['steps', params.steps], ['cfg_scale', params.cfgScale]] as const) {
+    const a = attr(key)
+    if (a) body[key] = a.default ?? Math.max(a.minimum ?? 0, Math.min(a.maximum ?? Infinity, fallback))
+  }
+  if (attr('n')) body.n = 1
+  if (attr('seed')) body.seed = params.seed !== undefined && params.seed >= 0 ? params.seed : Math.floor(Math.random() * Math.min(4294967296, (attr('seed')!.maximum ?? 4294967295) + 1))
+  if (params.negativePrompt) {
+    if (!attr('negative_prompt')) throw new Error('This OpenMayhem model does not support a negative prompt.')
+    body.negative_prompt = params.negativePrompt
+  }
+  for (const [key, value] of Object.entries(body)) if (key !== 'model' && attr(key)) validate(value, attr(key)!, key)
+  requiredFields(model, 'IMAGES', body)
+  return body
+}
+
+export class OpenMayhemImageClient implements ImageBackend {
+  constructor(private apiKey: string, private model: string) {}
+  async listModels(): Promise<string[]> { return (await loadOpenMayhemModels(true, 'IMAGES')).filter(hasAvailableOpenMayhemProvider).map((m) => m.id) }
+  async generateImage(params: ImageGenerateParams, signal?: AbortSignal): Promise<ImageGenerateResult> {
+    const model = await availableMediaModel('IMAGES', params.model || this.model)
+    const body = openMayhemImageBody(model, params)
+    const blob = await generateOpenMayhemMedia('IMAGES', this.apiKey, body, signal)
+    const bytes = new Uint8Array(await blob.arrayBuffer())
+    let binary = ''
+    for (let i = 0; i < bytes.length; i += 8192) binary += String.fromCharCode(...bytes.subarray(i, i + 8192))
+    return { base64: btoa(binary), mimeType: blob.type, seed: typeof body.seed === 'number' ? body.seed : undefined }
+  }
+}

--- a/src/lib/hooks/useOpenMayhemModels.ts
+++ b/src/lib/hooks/useOpenMayhemModels.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+import { hasAvailableOpenMayhemProvider, loadOpenMayhemModels, type OpenMayhemEndpoint, type OpenMayhemModel } from '@/lib/api/openMayhem'
+
+export function useOpenMayhemModels(endpoint: OpenMayhemEndpoint, enabled: boolean) {
+  const [models, setModels] = useState<OpenMayhemModel[] | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [nonce, setNonce] = useState(0)
+  useEffect(() => {
+    setModels(null)
+    setLoading(enabled)
+    if (!enabled) return
+    let disposed = false
+    let fetching = false
+    const refresh = async () => {
+      if (fetching) return
+      fetching = true
+      try {
+        const catalog = await loadOpenMayhemModels(true, endpoint)
+        if (!disposed) setModels(catalog.filter(hasAvailableOpenMayhemProvider).sort((a, b) => a.id.localeCompare(b.id)))
+      } catch { if (!disposed) setModels(null) }
+      finally { fetching = false; if (!disposed) setLoading(false) }
+    }
+    void refresh()
+    const timer = setInterval(refresh, 30000)
+    window.addEventListener('focus', refresh)
+    return () => { disposed = true; clearInterval(timer); window.removeEventListener('focus', refresh) }
+  }, [endpoint, enabled, nonce])
+  return { models, loading, reload: () => setNonce((n) => n + 1) }
+}

--- a/src/lib/store/chatBackendConfig.test.ts
+++ b/src/lib/store/chatBackendConfig.test.ts
@@ -8,6 +8,19 @@ beforeAll(async () => {
 afterAll(() => vi.unstubAllGlobals())
 
 describe('chat provider credentials', () => {
+  it('isolates shared OpenMayhem media credentials when switching image and speech providers', () => {
+    const s = useSettingsStore.getState()
+    s.setOpenMayhemApiKey('media-secret')
+    s.setVoiceConfig({ ttsProvider: 'elevenlabs', ttsApiKey: 'eleven-secret', ttsVoice: 'old-voice' })
+    s.setVoiceConfig({ ttsProvider: 'openmayhem' })
+    expect(useSettingsStore.getState()).toMatchObject({ ttsApiKey: '', ttsVoice: '', openMayhemApiKey: 'media-secret' })
+    s.setVoiceConfig({ ttsModel: 'speech/model' })
+    s.setImageBackendConfig({ imageBackend: 'novelai-image', imageBackendUsername: 'novel-secret', imageBackendModel: 'old-image' })
+    s.setImageBackendConfig({ imageBackend: 'openmayhem' })
+    expect(useSettingsStore.getState()).toMatchObject({ imageBackendUsername: '', imageBackendPassword: '', imageBackendModel: '', ttsModel: 'speech/model', openMayhemApiKey: 'media-secret' })
+    s.setVoiceConfig({ ttsProvider: 'openai-compatible' })
+    expect(useSettingsStore.getState()).toMatchObject({ ttsApiKey: '', ttsModel: '', openMayhemApiKey: 'media-secret' })
+  })
   it('clears the old key and model when entering and leaving OpenMayhem', () => {
     const set = useSettingsStore.getState().setChatBackendConfig
     set({ chatBackend: 'openai-compatible', chatBackendBaseUrl: 'https://example.test/v1', chatBackendApiKey: 'old-secret', chatBackendModel: 'old-model' })

--- a/src/lib/store/useSettingsStore.ts
+++ b/src/lib/store/useSettingsStore.ts
@@ -287,12 +287,17 @@ interface SettingsState {
   ttsBaseUrl: string
   ttsRegion: string
   ttsVoice: string
+  ttsModel: string
+  /** Shared only by OpenMayhem image generation and speech; never used for another provider. */
+  openMayhemApiKey: string
+  setOpenMayhemApiKey: (key: string) => void
   setVoiceConfig: (patch: Partial<{
     ttsProvider: TtsProviderId
     ttsApiKey: string
     ttsBaseUrl: string
     ttsRegion: string
     ttsVoice: string
+    ttsModel: string
   }>) => void
 
   /** Defaults to `'koboldcpp'`; the other three fields only matter for `'openai-compatible'`. */
@@ -496,7 +501,14 @@ export const useSettingsStore = create<SettingsState>()(
       ttsBaseUrl: '',
       ttsRegion: '',
       ttsVoice: '',
-      setVoiceConfig: (patch) => set(patch),
+      ttsModel: '',
+      openMayhemApiKey: '',
+      setOpenMayhemApiKey: (key) => set({ openMayhemApiKey: key }),
+      setVoiceConfig: (patch) => set((s) => {
+        const changesProvider = patch.ttsProvider !== undefined && patch.ttsProvider !== s.ttsProvider
+          || patch.ttsBaseUrl !== undefined && patch.ttsBaseUrl !== s.ttsBaseUrl
+        return changesProvider ? { ttsApiKey: '', ttsVoice: '', ttsModel: '', ...patch } : patch
+      }),
 
       chatBackend: 'koboldcpp',
       chatBackendBaseUrl: '',
@@ -517,7 +529,11 @@ export const useSettingsStore = create<SettingsState>()(
       imageBackendUsername: '',
       imageBackendPassword: '',
       imageBackendModel: '',
-      setImageBackendConfig: (patch) => set(patch),
+      setImageBackendConfig: (patch) => set((s) => {
+        const changesProvider = patch.imageBackend !== undefined && patch.imageBackend !== s.imageBackend
+          || patch.imageBackendBaseUrl !== undefined && patch.imageBackendBaseUrl !== s.imageBackendBaseUrl
+        return changesProvider ? { imageBackendUsername: '', imageBackendPassword: '', imageBackendModel: '', ...patch } : patch
+      }),
     }),
     {
       name: 'rp-settings',

--- a/src/lib/voice/ttsProviders.test.ts
+++ b/src/lib/voice/ttsProviders.test.ts
@@ -122,7 +122,7 @@ describe('synthesizeSpeech', () => {
 
   it('every provider has a label, including the unimplemented one', () => {
     expect(Object.keys(TTS_PROVIDER_LABELS).sort()).toEqual(
-      ['alibaba', 'azure', 'elevenlabs', 'koboldcpp', 'openai-compatible'].sort(),
+      ['alibaba', 'azure', 'elevenlabs', 'koboldcpp', 'openai-compatible', 'openmayhem'].sort(),
     )
   })
 

--- a/src/lib/voice/ttsProviders.ts
+++ b/src/lib/voice/ttsProviders.ts
@@ -1,7 +1,9 @@
 // Multi-provider text-to-speech. Every provider returns a playable audio Blob from
 // plain text — a caller doesn't need to know which provider is behind it.
 
-export type TtsProviderId = 'koboldcpp' | 'openai-compatible' | 'elevenlabs' | 'azure' | 'alibaba'
+import { speakOpenMayhem } from '../api/openMayhemMedia'
+
+export type TtsProviderId = 'koboldcpp' | 'openai-compatible' | 'elevenlabs' | 'azure' | 'alibaba' | 'openmayhem'
 
 export interface TtsConfig {
   provider: TtsProviderId
@@ -11,9 +13,11 @@ export interface TtsConfig {
   /** Azure region, e.g. "eastus". */
   region?: string
   voice: string
+  model?: string
 }
 
 export const TTS_PROVIDER_LABELS: Record<TtsProviderId, string> = {
+  openmayhem: 'OpenMayhem (hosted)',
   koboldcpp: 'KoboldCpp (local)',
   'openai-compatible': 'OpenAI-compatible (incl. local Kokoro)',
   elevenlabs: 'ElevenLabs',
@@ -72,7 +76,7 @@ async function speakAzure(apiKey: string, region: string, voiceName: string, tex
  * koboldcpp exposes an OpenAI-compatible /v1/audio/speech endpoint, so the local
  * provider is just the same call pointed at that URL with no API key.
  */
-export async function synthesizeSpeech(config: TtsConfig, text: string, koboldBaseUrl: string): Promise<Blob> {
+export async function synthesizeSpeech(config: TtsConfig, text: string, koboldBaseUrl: string, signal?: AbortSignal): Promise<Blob> {
   const trimmed = text.trim()
   if (!trimmed) throw new Error('Nothing to speak')
   // A pasted key/id/region with a trailing space or newline is a common, silent cause of a 401 —
@@ -84,6 +88,8 @@ export async function synthesizeSpeech(config: TtsConfig, text: string, koboldBa
   const region = config.region?.trim()
 
   switch (config.provider) {
+    case 'openmayhem':
+      return speakOpenMayhem(apiKey || '', config.model || '', trimmed, voice, signal)
     case 'koboldcpp':
       return speakOpenAiCompatible(koboldBaseUrl, undefined, trimmed, voice)
     case 'openai-compatible':


### PR DESCRIPTION
Add OpenMayhem image generation and text-to-speech to RP Suite's existing asset and Visual Novel workflows. Chat support was merged in #2; this PR adds media support and completes live catalog pagination across all three modalities.

- Add OpenMayhem to Images and Voice settings, with independent live model selections, model-provided voices, and an isolated shared media key. Character voice overrides use the selected speech model's supported voices.
- Submit image/speech jobs once, poll completion, retrieve owned artifacts through fixed local relay routes, and request cancellation on Stop/unmount. Preserve provider errors; never silently retry billed inference or forward keys to signed artifact download hosts.
- Use image model sampling defaults and fit slot dimensions to the contract. Preserve image MIME types and save generated assets through the existing local storage path. Integrate speech with the settings preview and Visual Novel playback, including cancellation and audio cleanup.
- Fetch every catalog page and refresh model selectors every 30 seconds/on focus. Only compatible models with available, non-stale providers are selectable; new compatible live models appear without code changes.

Validation: 2,027 tests across 109 files, TypeScript checks and production build pass. The final cancellation fix also passes all 23 focused media/router tests. Live browser tests used Z-Image Turbo for a settings preview a saved/reopened character portrait and a one-expression batch, and Chatterbox for the settings speech preview and Visual Novel read-aloud. The portrait was verified as a decoded 832x1216 asset served from RP Suite's local /avatars path. Tests cover pagination/new models, offline/stale filtering, contract bounds, voice selection, provider credential isolation, async polling/artifact retrieval, cancellation, and provider failures. See OPENMAYHEM.md for research, test details and limitations.

Provider availability can change between selection and dispatch. Stopping requests cancellation but work already performed may still be billed. Voice cloning, account balance/cost displays, and every possible future model are outside this change.

The live Stop test found and fixed OpenMayhem rejecting bodyless DELETE requests with JSON Content-Type. A fresh cancellation was accepted with HTTP 200, and the browser retest returned to idle without an error. A live chat provider also became unavailable during testing; its model disappeared from the dropdown as expected.
