### PR TITLE
Add OpenMayhem Krea 2 image models and a shared API key

### DIFF
--- a/OPENMAYHEM.md
+++ b/OPENMAYHEM.md
@@ -1,5 +1,21 @@
 # OpenMayhem integration
 
+## Krea base-image workflows (September 12, 2026)
+
+The image picker combines the paginated IMAGES catalog with supported image-producing WORKFLOWS entries. Users see Z-Image Turbo, Krea 2 Turbo, and Krea 2 Quality when their providers are available. Stable API IDs are saved separately from display names. Discovery still refreshes every 30 seconds/on focus, and generation rechecks availability before submitting. A catalog failure does not silently retain an obsolete selectable list.
+
+Krea support is based on `workflow_media` schema version 1 (`krea2-turbo` and `krea2-raw`), the published workflow policy, request contracts, and live image capacity. A small base-image adapter constructs ten reviewed graph roles from the advertised loader parts and allowed links. It never adds LoRA nodes, uses the model's default preset, and selects the published `turbo-negative` preset when a negative prompt is supplied. Unsupported metadata, required extra nodes, invalid sampling values, and unsupported inputs are rejected before submission. Other workflow families, image editing, references and optional LoRAs are outside this release.
+
+Slot dimensions fit the policy's grid, dimension bounds, and pixel capacity. Each job produces one image. Krea jobs go through the fixed `/api/openmayhem/workflows` relay and reuse image artifact validation, polling, cancellation, MIME preservation, and local asset storage. No new account, workflow editor, SDK dependency, or provider-specific setup is exposed in RP Suite.
+
+One OpenMayhem key now serves chat, images and voice. Editing it on an OpenMayhem settings page updates the shared key; switching chat to another provider clears that provider field without leaking the shared secret. On upgrade, a saved media key takes precedence if both legacy fields differ; otherwise an existing OpenMayhem chat key is reused. Restricted API keys need Chat, Images, Audio Speech, and Workflows permissions for the corresponding features.
+
+Test fixtures were captured from the public catalog on September 12; provider identities and optional LoRA catalogs were removed. They are test data only, never bundled as runtime model choices. Automated coverage includes graph construction without LoRAs, Turbo negative prompts, capacity/ratio fitting, unknown metadata rejection, live paginated discovery, workflow execution, cancellation, relay authorization, and shared-key migration/isolation.
+
+Live validation generated images with all three models. Browser checks covered the three friendly choices, persisted Krea selection, a Turbo preview, and a Quality portrait created and reopened from local avatar storage at 832x1216. Separate image-client calls downloaded a Z-Image landscape and a 768x512 Turbo landscape with a negative prompt, seed 42, ten graph nodes, and zero LoRA nodes. A temporary OpenMayhem maintenance 503 was displayed without automatic resubmission; an explicit retry later succeeded. Browser Stop returned to idle without a cancellation error, but the provider job ultimately completed: this is cancellation-request handling, not a guarantee of stopped work or refunded credit.
+
+Validation: 2,142 tests across 114 files passed; the final metadata checks were also retested separately. TypeScript and production build are checked before opening the PR. The browser retains a local `Krea integration test` character for manual inspection. No API keys or generated personal assets are included in the PR.
+
 ## Recommended first release
 
 Use the existing OpenAI-compatible chat backend with a named OpenMayhem preset, plus dedicated async image and speech adapters in the existing media workflows. Keep signup, email/card verification, credit claims, key issuance, and payments on OpenMayhem. The user returns to RP Suite with an API key and chooses a model. This avoids introducing a second account system or embedding payment handling in a local roleplay client.

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ OpenMayhem uses `https://api.openmayhem.ai/v1`. Requests pass through RP Suite's
 
 The connection check reads the public catalog without spending credit; it does **not** validate your key or balance. Those are checked on your first inference request. See [OpenMayhem integration notes](OPENMAYHEM.md) for behavior, research, and validation limits.
 
-For images and speech, choose **OpenMayhem** in **Settings > Images** and **Settings > Voice**. Enter a media key with Images and Audio Speech permissions (or use the button to copy your OpenMayhem chat key), then choose each model. Voice options also come from the selected model. The image preview and voice test perform real, billed generation.
+For images and speech, choose **OpenMayhem** in **Settings > Images** and **Settings > Voice**. One OpenMayhem key is shared across chat, images and voice. Enable Chat, Images, Audio Speech and Workflows permissions for the features you use. The image picker includes **Z-Image Turbo**, **Krea 2 Turbo** and **Krea 2 Quality** when available. Krea uses its base model and published preset without additional LoRAs; RP Suite handles the workflow automatically. Voice options also come from the selected model. The image preview and voice test perform real, billed generation.
 
-All three model lists load every catalog page and refresh every 30 seconds and on window focus. Only compatible models with available, non-stale providers are selectable, so newly added live models appear automatically. Images use model sampling defaults and slot dimensions adapted to its limits. Stop requests media-job cancellation; completed work may still cost credit. Generated assets saved to a character or world remain stored locally.
+All three model lists load every catalog page and refresh every 30 seconds and on window focus. Only compatible models with available, non-stale providers are selectable. New models using supported image/chat/speech interfaces or supported Krea base-image workflow metadata appear automatically; other workflow families need an adapter. Images use model sampling defaults and slot dimensions adapted to its limits. Stop requests media-job cancellation; completed work may still cost credit. Generated assets saved to a character or world remain stored locally.
 
 ### Characters
 

--- a/server/openMayhem.test.ts
+++ b/server/openMayhem.test.ts
@@ -82,7 +82,7 @@ describe('OpenMayhem local forwarding', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
   it('requires authorization for job status, cancellation, artifacts and both generation endpoints', async () => {
-    for (const [path, method] of [['/jobs/job_1', 'GET'], ['/jobs/job_1', 'DELETE'], ['/artifacts/a_1', 'GET'], ['/images/generations', 'POST'], ['/audio/speech', 'POST']]) {
+    for (const [path, method] of [['/jobs/job_1', 'GET'], ['/jobs/job_1', 'DELETE'], ['/artifacts/a_1', 'GET'], ['/images/generations', 'POST'], ['/workflows', 'POST'], ['/audio/speech', 'POST']]) {
       expect((await call(path, method)).status).toBe(401)
       fetchMock.mockResolvedValueOnce(new Response('{}'))
       expect((await call(path, method, { Authorization: 'Bearer media-key' }, method === 'POST' ? { model: 'test' } : undefined)).status).toBe(200)
@@ -93,6 +93,12 @@ describe('OpenMayhem local forwarding', () => {
         expect(fetchMock.mock.lastCall?.[1].body).toBeUndefined()
       }
     }
+  })
+  it('loads workflow metadata through the public catalog without forwarding credentials', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('{"data":[]}'))
+    expect((await call('/models?endpoint_family=WORKFLOWS', 'GET', { Authorization: 'Bearer private' })).status).toBe(200)
+    expect(fetchMock.mock.lastCall?.[0]).toBe('https://api.openmayhem.ai/v1/models?endpoint_family=WORKFLOWS&limit=100')
+    expect(fetchMock.mock.lastCall?.[1].headers).toEqual({ Accept: 'application/json' })
   })
   it('downloads a signed artifact redirect without forwarding the bearer or cookies', async () => {
     fetchMock.mockResolvedValueOnce(new Response(null, { status: 302, headers: { Location: 'https://bucket.s3.amazonaws.com/signed-artifact?signature=abc' } }))

--- a/server/openMayhem.ts
+++ b/server/openMayhem.ts
@@ -12,6 +12,7 @@ export function openMayhemRouter() {
     ['get', '/campaign', '/campaigns/featured'],
     ['post', '/chat/completions', '/v1/chat/completions'],
     ['post', '/images/generations', '/v1/images/generations'],
+    ['post', '/workflows', '/v1/workflows'],
     ['post', '/audio/speech', '/v1/audio/speech'],
     ['get', '/jobs/:id', '/v1/jobs/'],
     ['delete', '/jobs/:id', '/v1/jobs/'],
@@ -25,7 +26,7 @@ export function openMayhemRouter() {
       if (localPath === '/models') {
         const endpoint = req.query.endpoint_family ?? 'CHAT'
         const cursor = req.query.cursor
-        if (!['CHAT', 'IMAGES', 'AUDIO_SPEECH'].includes(endpoint as string)
+        if (!['CHAT', 'IMAGES', 'AUDIO_SPEECH', 'WORKFLOWS'].includes(endpoint as string)
           || (cursor !== undefined && (typeof cursor !== 'string' || cursor.length > 4096))) {
           res.status(400).json({ error: { message: 'Invalid model catalog query.' } }); return
         }

--- a/src/components/settings/ImageGenSettings.tsx
+++ b/src/components/settings/ImageGenSettings.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { openMayhemImageLabel } from '@/lib/api/openMayhemKrea'
 import { useOpenMayhemModels } from '@/lib/hooks/useOpenMayhemModels'
 import { OpenMayhemModelSelect } from './OpenMayhemModelSelect'
 import { OpenMayhemMediaKey } from './OpenMayhemMediaKey'
@@ -63,6 +64,7 @@ export function ImageGenSettings() {
         {imageBackend === 'openmayhem' && <>
           <OpenMayhemMediaKey />
           <OpenMayhemModelSelect kind="image" models={models?.map((m) => m.id) ?? null} loading={loading} value={imageBackendModel}
+            labels={Object.fromEntries((models ?? []).map((m) => [m.id, openMayhemImageLabel(m)]))}
             onChange={(model) => { setImageBackendConfig({ imageBackendModel: model }); setPreview('') }} />
           <Button onClick={reload} disabled={loading}>Refresh models</Button>
           <p className="my-3 text-xs text-text-muted">Uses the selected model's default steps and guidance. Image dimensions fit the slot and the model's limits. Each image is a billed job; stopping requests cancellation, but work already done may still be billed.</p>

--- a/src/components/settings/OpenMayhemMediaKey.tsx
+++ b/src/components/settings/OpenMayhemMediaKey.tsx
@@ -1,19 +1,13 @@
 import { useSettingsStore } from '@/lib/store/useSettingsStore'
-import { isOpenMayhem } from '@/lib/api/openMayhem'
 import { TextField } from '@/components/ui/Field'
-import { Button } from '@/components/ui/Button'
 import { OpenMayhemSetup } from './OpenMayhemSetup'
 
 export function OpenMayhemMediaKey() {
   const key = useSettingsStore((s) => s.openMayhemApiKey)
   const setKey = useSettingsStore((s) => s.setOpenMayhemApiKey)
-  const chatKey = useSettingsStore((s) => s.chatBackendApiKey)
-  const chatUrl = useSettingsStore((s) => s.chatBackendBaseUrl)
-  const chatBackend = useSettingsStore((s) => s.chatBackend)
   return <>
     <OpenMayhemSetup media />
-    <TextField label="OpenMayhem media API key" type="password" value={key} onChange={(e) => setKey(e.target.value)}
-      hint="Shared by OpenMayhem Images and Voice. Stored in this browser; requests pass through RP Suite's local relay to OpenMayhem." />
-    {chatBackend === 'openai-compatible' && isOpenMayhem(chatUrl) && chatKey && <Button onClick={() => setKey(chatKey)}>Use OpenMayhem chat key</Button>}
+    <TextField label="OpenMayhem API key" type="password" value={key} onChange={(e) => setKey(e.target.value)}
+      hint="One key for OpenMayhem chat, images and voice. Stored in this browser." />
   </>
 }

--- a/src/components/settings/OpenMayhemModelSelect.tsx
+++ b/src/components/settings/OpenMayhemModelSelect.tsx
@@ -1,6 +1,7 @@
 import { SelectField } from '@/components/ui/Field'
 
-export function OpenMayhemModelSelect({ models, loading, value, onChange, kind = 'chat' }: {
+export function OpenMayhemModelSelect({ models, loading, value, onChange, kind = 'chat', labels }: {
+  labels?: Record<string, string>
   kind?: 'chat' | 'image' | 'speech'
   models: string[] | null
   loading: boolean
@@ -18,7 +19,7 @@ export function OpenMayhemModelSelect({ models, loading, value, onChange, kind =
     <SelectField label="Model" value={selected ? value : ''} disabled={options.length === 0}
       onChange={(e) => onChange(e.target.value)} hint={hint}>
       {!selected && <option value="" disabled>{loading ? 'Loading models…' : options.length ? 'Choose an available model…' : 'No available models'}</option>}
-      {options.map((model) => <option key={model} value={model}>{model}</option>)}
+      {options.map((model) => <option key={model} value={model}>{labels?.[model] || model}</option>)}
     </SelectField>
   )
 }

--- a/src/components/settings/OpenMayhemSetup.tsx
+++ b/src/components/settings/OpenMayhemSetup.tsx
@@ -37,7 +37,7 @@ export function OpenMayhemSetup({ media = false }: { media?: boolean }) {
             <a className={LINK} href="https://openmayhem.ai/dashboard/credits" target="_blank" rel="noopener noreferrer">Check credits and current offers</a> on OpenMayhem.
           </>}
         </li>
-        <li><a className={LINK} href="https://openmayhem.ai/dashboard/keys" target="_blank" rel="noopener noreferrer">Create an API key</a> with {media ? 'Images and Audio Speech' : 'Chat'} permission, paste it below, then choose a model.</li>
+        <li><a className={LINK} href="https://openmayhem.ai/dashboard/keys" target="_blank" rel="noopener noreferrer">Create an API key</a> with access to the models you want to use, paste it below, then choose a model. The same key works across OpenMayhem chat, images and voice.</li>
       </ol>
       <p className="mt-3">{media ? 'Images and speech use your OpenMayhem credits. Prompts, speech text, and your key pass through your RP Suite server to OpenMayhem.' : 'Replies and background scoring use your OpenMayhem credits. Chats stay saved here; prompts and your key pass through your RP Suite server to OpenMayhem for inference.'}</p>
       {!media && <p className="mt-2">Thinking is disabled when the model supports it so short replies and scoring calls have room to answer. Stopping a reply may still incur the provider’s generation cost.</p>}

--- a/src/lib/api/fixtures/krea-quality.json
+++ b/src/lib/api/fixtures/krea-quality.json
@@ -1,0 +1,609 @@
+{
+  "id": "image.heavy.le4_5mp",
+  "name": "Krea 2 Raw / Quality",
+  "endpoints": [
+    "WORKFLOWS"
+  ],
+  "providers_available": 1,
+  "availability_stale": false,
+  "workflow_media": {
+    "schema_version": 1,
+    "kind": "image",
+    "family": "krea2-raw",
+    "loras": [],
+    "presets": [
+      {
+        "id": "raw-card",
+        "name": "Raw \u2014 creator card",
+        "inputs": [
+          {
+            "role": "sampler",
+            "input": "steps",
+            "value": 52
+          },
+          {
+            "role": "sampler",
+            "input": "cfg",
+            "value": 4.5
+          },
+          {
+            "role": "sampler",
+            "input": "sampler_name",
+            "value": "euler"
+          },
+          {
+            "role": "sampler",
+            "input": "scheduler",
+            "value": "simple"
+          },
+          {
+            "role": "sampling",
+            "input": "base_shift",
+            "value": 0.5
+          },
+          {
+            "role": "sampling",
+            "input": "max_shift",
+            "value": 0.90625
+          }
+        ]
+      },
+      {
+        "id": "raw-official-space",
+        "name": "Raw \u2014 official space",
+        "inputs": [
+          {
+            "role": "sampler",
+            "input": "steps",
+            "value": 28
+          },
+          {
+            "role": "sampler",
+            "input": "cfg",
+            "value": 5.5
+          },
+          {
+            "role": "sampler",
+            "input": "sampler_name",
+            "value": "euler"
+          },
+          {
+            "role": "sampler",
+            "input": "scheduler",
+            "value": "simple"
+          },
+          {
+            "role": "sampling",
+            "input": "base_shift",
+            "value": 0.5
+          },
+          {
+            "role": "sampling",
+            "input": "max_shift",
+            "value": 0.90625
+          }
+        ]
+      }
+    ],
+    "default_preset": "raw-card"
+  },
+  "workflow": {
+    "whitelisted_nodes": [
+      "CLIPLoader",
+      "CLIPTextEncode",
+      "EmptyLatentImage",
+      "KSampler",
+      "LoraLoaderModelOnly",
+      "ModelSamplingFlux",
+      "SaveImage",
+      "UNETLoader",
+      "VAEDecode",
+      "VAELoader"
+    ],
+    "parts": [
+      {
+        "part_id": "b115d35ad309c056f86682a08215d7be02183a66a3c731d1e3b2f1b388d81a1c",
+        "name": "krea2_raw_fp8_scaled.safetensors",
+        "type": "checkpoint",
+        "sha256": "48cd5d6c100297968349b41a8e77c6591d1dac18a215807f5f25f59e5c54cd61"
+      },
+      {
+        "part_id": "19d454e5e0516af43d0a6aee3aefd468897851bd879add036fe1b9350b66825c",
+        "name": "qwen3vl_4b_fp8_scaled.safetensors",
+        "type": "text-encoder",
+        "sha256": "54bd5144df0bbc25dd6ccadfcb826b521445a1b06ae5a42570bdd2974ca87094"
+      },
+      {
+        "part_id": "106d81a4897fa125d63b62fbcf2d7d1e88dc66f1b89e6f793f7142f928c7aa70",
+        "name": "qwen_image_vae.safetensors",
+        "type": "vae",
+        "sha256": "a70580f0213e67967ee9c95f05bb400e8fb08307e017a924bf3441223e023d1f"
+      }
+    ],
+    "runtime_id": "comfyui-v0.30.1",
+    "outcome_class": "image.heavy.le4_5mp",
+    "pricing_unit": "megapixel_step",
+    "max_nodes": 14,
+    "max_width": 2048,
+    "max_height": 2048,
+    "max_frames": 1,
+    "max_duration_seconds": 1,
+    "max_steps": 52,
+    "max_artifacts": 4,
+    "dimension_bounds": {
+      "min_width": 256,
+      "min_height": 256,
+      "max_pixels": 4500000,
+      "width_multiple": 64,
+      "height_multiple": 64
+    },
+    "graph_constraints": {
+      "output_role": "output",
+      "roles": {
+        "clip": {
+          "class_type": "CLIPLoader",
+          "min_count": 1,
+          "max_count": 1,
+          "inputs": {
+            "clip_name": {
+              "value_type": "part",
+              "required": true,
+              "part_type": "text-encoder",
+              "part_names": [
+                "qwen3vl_4b_fp8_scaled.safetensors"
+              ],
+              "distinct": false
+            },
+            "device": {
+              "value_type": "string",
+              "required": true,
+              "fixed": "default",
+              "distinct": false
+            },
+            "type": {
+              "value_type": "string",
+              "required": true,
+              "fixed": "krea2",
+              "distinct": false
+            }
+          }
+        },
+        "decode": {
+          "class_type": "VAEDecode",
+          "min_count": 1,
+          "max_count": 1,
+          "inputs": {
+            "samples": {
+              "value_type": "link",
+              "required": true,
+              "distinct": false,
+              "sources": [
+                {
+                  "role": "sampler",
+                  "output": 0
+                }
+              ]
+            },
+            "vae": {
+              "value_type": "link",
+              "required": true,
+              "distinct": false,
+              "sources": [
+                {
+                  "role": "vae",
+                  "output": 0
+                }
+              ]
+            }
+          }
+        },
+        "denoiser": {
+          "class_type": "UNETLoader",
+          "min_count": 1,
+          "max_count": 1,
+          "inputs": {
+            "unet_name": {
+              "value_type": "part",
+              "required": true,
+              "part_type": "checkpoint",
+              "part_names": [
+                "krea2_raw_fp8_scaled.safetensors"
+              ],
+              "distinct": false
+            },
+            "weight_dtype": {
+              "value_type": "string",
+              "required": true,
+              "fixed": "default",
+              "distinct": false
+            }
+          }
+        },
+        "latent": {
+          "class_type": "EmptyLatentImage",
+          "min_count": 1,
+          "max_count": 1,
+          "inputs": {
+            "batch_size": {
+              "value_type": "integer",
+              "required": true,
+              "minimum": 1,
+              "maximum": 4,
+              "distinct": false
+            },
+            "height": {
+              "value_type": "integer",
+              "required": true,
+              "minimum": 256,
+              "maximum": 2048,
+              "multiple_of": 64,
+              "distinct": false
+            },
+            "width": {
+              "value_type": "integer",
+              "required": true,
+              "minimum": 256,
+              "maximum": 2048,
+              "multiple_of": 64,
+              "distinct": false
+            }
+          }
+        },
+        "negative": {
+          "class_type": "CLIPTextEncode",
+          "min_count": 1,
+          "max_count": 1,
+          "inputs": {
+            "clip": {
+              "value_type": "link",
+              "required": true,
+              "distinct": false,
+              "sources": [
+                {
+                  "role": "clip",
+                  "output": 0
+                }
+              ]
+            },
+            "text": {
+              "value_type": "string",
+              "required": true,
+              "min_length": 0,
+              "max_length": 16384,
+              "distinct": false
+            }
+          }
+        },
+        "output": {
+          "class_type": "SaveImage",
+          "min_count": 1,
+          "max_count": 1,
+          "inputs": {
+            "filename_prefix": {
+              "value_type": "string",
+              "required": true,
+              "min_length": 1,
+              "max_length": 128,
+              "distinct": false
+            },
+            "images": {
+              "value_type": "link",
+              "required": true,
+              "distinct": false,
+              "sources": [
+                {
+                  "role": "decode",
+                  "output": 0
+                }
+              ]
+            }
+          }
+        },
+        "positive": {
+          "class_type": "CLIPTextEncode",
+          "min_count": 1,
+          "max_count": 1,
+          "inputs": {
+            "clip": {
+              "value_type": "link",
+              "required": true,
+              "distinct": false,
+              "sources": [
+                {
+                  "role": "clip",
+                  "output": 0
+                }
+              ]
+            },
+            "text": {
+              "value_type": "string",
+              "required": true,
+              "min_length": 0,
+              "max_length": 16384,
+              "distinct": false
+            }
+          }
+        },
+        "sampler": {
+          "class_type": "KSampler",
+          "min_count": 1,
+          "max_count": 1,
+          "inputs": {
+            "cfg": {
+              "value_type": "number",
+              "required": true,
+              "minimum": 1,
+              "maximum": 5.5,
+              "distinct": false
+            },
+            "denoise": {
+              "value_type": "number",
+              "required": true,
+              "fixed": 1,
+              "distinct": false
+            },
+            "latent_image": {
+              "value_type": "link",
+              "required": true,
+              "distinct": false,
+              "sources": [
+                {
+                  "role": "latent",
+                  "output": 0
+                }
+              ]
+            },
+            "model": {
+              "value_type": "link",
+              "required": true,
+              "distinct": false,
+              "sources": [
+                {
+                  "role": "sampling",
+                  "output": 0
+                }
+              ]
+            },
+            "negative": {
+              "value_type": "link",
+              "required": true,
+              "distinct": false,
+              "sources": [
+                {
+                  "role": "negative",
+                  "output": 0
+                }
+              ]
+            },
+            "positive": {
+              "value_type": "link",
+              "required": true,
+              "distinct": false,
+              "sources": [
+                {
+                  "role": "positive",
+                  "output": 0
+                }
+              ]
+            },
+            "sampler_name": {
+              "value_type": "string",
+              "required": true,
+              "enum_values": [
+                "euler"
+              ],
+              "distinct": false
+            },
+            "scheduler": {
+              "value_type": "string",
+              "required": true,
+              "enum_values": [
+                "simple"
+              ],
+              "distinct": false
+            },
+            "seed": {
+              "value_type": "integer",
+              "required": true,
+              "minimum": 0,
+              "maximum": 9007199254740991,
+              "distinct": false
+            },
+            "steps": {
+              "value_type": "integer",
+              "required": true,
+              "minimum": 1,
+              "maximum": 52,
+              "distinct": false
+            }
+          }
+        },
+        "sampling": {
+          "class_type": "ModelSamplingFlux",
+          "min_count": 1,
+          "max_count": 1,
+          "inputs": {
+            "base_shift": {
+              "value_type": "number",
+              "required": true,
+              "minimum": 0,
+              "maximum": 2,
+              "distinct": false
+            },
+            "height": {
+              "value_type": "integer",
+              "required": true,
+              "minimum": 256,
+              "maximum": 2048,
+              "multiple_of": 64,
+              "distinct": false,
+              "same_value_as": {
+                "role": "latent",
+                "input": "height"
+              }
+            },
+            "max_shift": {
+              "value_type": "number",
+              "required": true,
+              "minimum": 0,
+              "maximum": 2,
+              "distinct": false
+            },
+            "model": {
+              "value_type": "link",
+              "required": true,
+              "distinct": false,
+              "sources": [
+                {
+                  "role": "user_lora",
+                  "output": 0
+                },
+                {
+                  "role": "denoiser",
+                  "output": 0
+                }
+              ]
+            },
+            "width": {
+              "value_type": "integer",
+              "required": true,
+              "minimum": 256,
+              "maximum": 2048,
+              "multiple_of": 64,
+              "distinct": false,
+              "same_value_as": {
+                "role": "latent",
+                "input": "width"
+              }
+            }
+          }
+        },
+        "user_lora": {
+          "class_type": "LoraLoaderModelOnly",
+          "min_count": 0,
+          "max_count": 4,
+          "inputs": {
+            "lora_name": {
+              "value_type": "part",
+              "required": true,
+              "part_type": "lora",
+              "part_names": [],
+              "distinct": true
+            },
+            "model": {
+              "value_type": "link",
+              "required": true,
+              "distinct": false,
+              "sources": [
+                {
+                  "role": "user_lora",
+                  "output": 0
+                },
+                {
+                  "role": "denoiser",
+                  "output": 0
+                }
+              ]
+            },
+            "strength_model": {
+              "value_type": "number",
+              "required": true,
+              "minimum": -2,
+              "maximum": 2,
+              "distinct": false
+            }
+          }
+        },
+        "vae": {
+          "class_type": "VAELoader",
+          "min_count": 1,
+          "max_count": 1,
+          "inputs": {
+            "vae_name": {
+              "value_type": "part",
+              "required": true,
+              "part_type": "vae",
+              "part_names": [
+                "qwen_image_vae.safetensors"
+              ],
+              "distinct": false
+            }
+          }
+        }
+      }
+    }
+  },
+  "request_contracts": [
+    {
+      "family": "mayhem_comfy_workflows",
+      "endpoint": "WORKFLOWS",
+      "required": [
+        "model",
+        "workflow"
+      ],
+      "attributes": {
+        "user": {
+          "maxLength": 512,
+          "minLength": 1,
+          "valueTypes": [
+            "string"
+          ]
+        },
+        "model": {
+          "valueTypes": [
+            "string"
+          ]
+        },
+        "workflow": {
+          "valueTypes": [
+            "object"
+          ]
+        },
+        "runtime_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "valueTypes": [
+            "string"
+          ]
+        },
+        "timeout_ms": {
+          "default": 120000,
+          "maximum": 3600000,
+          "minimum": 1000,
+          "valueTypes": [
+            "integer"
+          ]
+        },
+        "outcome_class": {
+          "maxLength": 128,
+          "minLength": 1,
+          "valueTypes": [
+            "string"
+          ]
+        },
+        "response_format": {
+          "default": "artifact",
+          "enumValues": [
+            "artifact",
+            "json"
+          ],
+          "valueTypes": [
+            "string"
+          ]
+        }
+      }
+    }
+  ],
+  "live_capacity_profiles": [
+    {
+      "modalities": {
+        "image": {
+          "unit": "pixel",
+          "maxItemsPerRequest": 1,
+          "maxItemBytes": 6379935,
+          "maxItemUnits": 4194304
+        }
+      }
+    }
+  ]
+}

--- a/src/lib/api/fixtures/krea-turbo.json
+++ b/src/lib/api/fixtures/krea-turbo.json
@@ -1,0 +1,609 @@
+{
+  "id": "image.heavy.le1_2mp",
+  "name": "Krea 2 Turbo",
+  "endpoints": [
+    "WORKFLOWS"
+  ],
+  "providers_available": 1,
+  "availability_stale": false,
+  "workflow_media": {
+    "schema_version": 1,
+    "kind": "image",
+    "family": "krea2-turbo",
+    "loras": [],
+    "presets": [
+      {
+        "id": "turbo",
+        "name": "Turbo",
+        "inputs": [
+          {
+            "role": "sampler",
+            "input": "steps",
+            "value": 8
+          },
+          {
+            "role": "sampler",
+            "input": "cfg",
+            "value": 1
+          },
+          {
+            "role": "sampler",
+            "input": "sampler_name",
+            "value": "euler"
+          },
+          {
+            "role": "sampler",
+            "input": "scheduler",
+            "value": "simple"
+          },
+          {
+            "role": "sampling",
+            "input": "base_shift",
+            "value": 1.15
+          },
+          {
+            "role": "sampling",
+            "input": "max_shift",
+            "value": 1.15
+          }
+        ]
+      },
+      {
+        "id": "turbo-negative",
+        "name": "Turbo \u2014 negative prompt",
+        "inputs": [
+          {
+            "role": "sampler",
+            "input": "steps",
+            "value": 8
+          },
+          {
+            "role": "sampler",
+            "input": "cfg",
+            "value": 4
+          },
+          {
+            "role": "sampler",
+            "input": "sampler_name",
+            "value": "euler"
+          },
+          {
+            "role": "sampler",
+            "input": "scheduler",
+            "value": "simple"
+          },
+          {
+            "role": "sampling",
+            "input": "base_shift",
+            "value": 1.15
+          },
+          {
+            "role": "sampling",
+            "input": "max_shift",
+            "value": 1.15
+          }
+        ]
+      }
+    ],
+    "default_preset": "turbo"
+  },
+  "workflow": {
+    "whitelisted_nodes": [
+      "CLIPLoader",
+      "CLIPTextEncode",
+      "EmptySD3LatentImage",
+      "KSampler",
+      "LoraLoaderModelOnly",
+      "ModelSamplingFlux",
+      "SaveImage",
+      "UNETLoader",
+      "VAEDecode",
+      "VAELoader"
+    ],
+    "parts": [
+      {
+        "part_id": "6335241281bfe4537bda70cab1aca27211a9afb14197740c16778a253836bdae",
+        "name": "krea2_turbo_fp8_scaled.safetensors",
+        "type": "checkpoint",
+        "sha256": "eb4dd8c612cfd10f64f25b057e6e6bbcb5737c94a7372177e456dbf7579502f1"
+      },
+      {
+        "part_id": "19d454e5e0516af43d0a6aee3aefd468897851bd879add036fe1b9350b66825c",
+        "name": "qwen3vl_4b_fp8_scaled.safetensors",
+        "type": "text-encoder",
+        "sha256": "54bd5144df0bbc25dd6ccadfcb826b521445a1b06ae5a42570bdd2974ca87094"
+      },
+      {
+        "part_id": "106d81a4897fa125d63b62fbcf2d7d1e88dc66f1b89e6f793f7142f928c7aa70",
+        "name": "qwen_image_vae.safetensors",
+        "type": "vae",
+        "sha256": "a70580f0213e67967ee9c95f05bb400e8fb08307e017a924bf3441223e023d1f"
+      }
+    ],
+    "runtime_id": "comfyui-v0.30.1",
+    "outcome_class": "image.heavy.le1_2mp",
+    "pricing_unit": "megapixel_step",
+    "max_nodes": 14,
+    "max_width": 1920,
+    "max_height": 1920,
+    "max_frames": 1,
+    "max_duration_seconds": 1,
+    "max_steps": 8,
+    "max_artifacts": 4,
+    "dimension_bounds": {
+      "min_width": 256,
+      "min_height": 256,
+      "max_pixels": 1200000,
+      "width_multiple": 64,
+      "height_multiple": 64
+    },
+    "graph_constraints": {
+      "output_role": "output",
+      "roles": {
+        "clip": {
+          "class_type": "CLIPLoader",
+          "min_count": 1,
+          "max_count": 1,
+          "inputs": {
+            "clip_name": {
+              "value_type": "part",
+              "required": true,
+              "part_type": "text-encoder",
+              "part_names": [
+                "qwen3vl_4b_fp8_scaled.safetensors"
+              ],
+              "distinct": false
+            },
+            "device": {
+              "value_type": "string",
+              "required": true,
+              "fixed": "default",
+              "distinct": false
+            },
+            "type": {
+              "value_type": "string",
+              "required": true,
+              "fixed": "krea2",
+              "distinct": false
+            }
+          }
+        },
+        "decode": {
+          "class_type": "VAEDecode",
+          "min_count": 1,
+          "max_count": 1,
+          "inputs": {
+            "samples": {
+              "value_type": "link",
+              "required": true,
+              "distinct": false,
+              "sources": [
+                {
+                  "role": "sampler",
+                  "output": 0
+                }
+              ]
+            },
+            "vae": {
+              "value_type": "link",
+              "required": true,
+              "distinct": false,
+              "sources": [
+                {
+                  "role": "vae",
+                  "output": 0
+                }
+              ]
+            }
+          }
+        },
+        "denoiser": {
+          "class_type": "UNETLoader",
+          "min_count": 1,
+          "max_count": 1,
+          "inputs": {
+            "unet_name": {
+              "value_type": "part",
+              "required": true,
+              "part_type": "checkpoint",
+              "part_names": [
+                "krea2_turbo_fp8_scaled.safetensors"
+              ],
+              "distinct": false
+            },
+            "weight_dtype": {
+              "value_type": "string",
+              "required": true,
+              "fixed": "default",
+              "distinct": false
+            }
+          }
+        },
+        "latent": {
+          "class_type": "EmptySD3LatentImage",
+          "min_count": 1,
+          "max_count": 1,
+          "inputs": {
+            "batch_size": {
+              "value_type": "integer",
+              "required": true,
+              "minimum": 1,
+              "maximum": 4,
+              "distinct": false
+            },
+            "height": {
+              "value_type": "integer",
+              "required": true,
+              "minimum": 256,
+              "maximum": 1920,
+              "multiple_of": 64,
+              "distinct": false
+            },
+            "width": {
+              "value_type": "integer",
+              "required": true,
+              "minimum": 256,
+              "maximum": 1920,
+              "multiple_of": 64,
+              "distinct": false
+            }
+          }
+        },
+        "negative": {
+          "class_type": "CLIPTextEncode",
+          "min_count": 1,
+          "max_count": 1,
+          "inputs": {
+            "clip": {
+              "value_type": "link",
+              "required": true,
+              "distinct": false,
+              "sources": [
+                {
+                  "role": "clip",
+                  "output": 0
+                }
+              ]
+            },
+            "text": {
+              "value_type": "string",
+              "required": true,
+              "min_length": 0,
+              "max_length": 16384,
+              "distinct": false
+            }
+          }
+        },
+        "output": {
+          "class_type": "SaveImage",
+          "min_count": 1,
+          "max_count": 1,
+          "inputs": {
+            "filename_prefix": {
+              "value_type": "string",
+              "required": true,
+              "min_length": 1,
+              "max_length": 128,
+              "distinct": false
+            },
+            "images": {
+              "value_type": "link",
+              "required": true,
+              "distinct": false,
+              "sources": [
+                {
+                  "role": "decode",
+                  "output": 0
+                }
+              ]
+            }
+          }
+        },
+        "positive": {
+          "class_type": "CLIPTextEncode",
+          "min_count": 1,
+          "max_count": 1,
+          "inputs": {
+            "clip": {
+              "value_type": "link",
+              "required": true,
+              "distinct": false,
+              "sources": [
+                {
+                  "role": "clip",
+                  "output": 0
+                }
+              ]
+            },
+            "text": {
+              "value_type": "string",
+              "required": true,
+              "min_length": 0,
+              "max_length": 16384,
+              "distinct": false
+            }
+          }
+        },
+        "sampler": {
+          "class_type": "KSampler",
+          "min_count": 1,
+          "max_count": 1,
+          "inputs": {
+            "cfg": {
+              "value_type": "number",
+              "required": true,
+              "minimum": 1,
+              "maximum": 4,
+              "distinct": false
+            },
+            "denoise": {
+              "value_type": "number",
+              "required": true,
+              "fixed": 1,
+              "distinct": false
+            },
+            "latent_image": {
+              "value_type": "link",
+              "required": true,
+              "distinct": false,
+              "sources": [
+                {
+                  "role": "latent",
+                  "output": 0
+                }
+              ]
+            },
+            "model": {
+              "value_type": "link",
+              "required": true,
+              "distinct": false,
+              "sources": [
+                {
+                  "role": "sampling",
+                  "output": 0
+                }
+              ]
+            },
+            "negative": {
+              "value_type": "link",
+              "required": true,
+              "distinct": false,
+              "sources": [
+                {
+                  "role": "negative",
+                  "output": 0
+                }
+              ]
+            },
+            "positive": {
+              "value_type": "link",
+              "required": true,
+              "distinct": false,
+              "sources": [
+                {
+                  "role": "positive",
+                  "output": 0
+                }
+              ]
+            },
+            "sampler_name": {
+              "value_type": "string",
+              "required": true,
+              "enum_values": [
+                "euler"
+              ],
+              "distinct": false
+            },
+            "scheduler": {
+              "value_type": "string",
+              "required": true,
+              "enum_values": [
+                "simple"
+              ],
+              "distinct": false
+            },
+            "seed": {
+              "value_type": "integer",
+              "required": true,
+              "minimum": 0,
+              "maximum": 9007199254740991,
+              "distinct": false
+            },
+            "steps": {
+              "value_type": "integer",
+              "required": true,
+              "minimum": 1,
+              "maximum": 8,
+              "distinct": false
+            }
+          }
+        },
+        "sampling": {
+          "class_type": "ModelSamplingFlux",
+          "min_count": 1,
+          "max_count": 1,
+          "inputs": {
+            "base_shift": {
+              "value_type": "number",
+              "required": true,
+              "minimum": 0,
+              "maximum": 2,
+              "distinct": false
+            },
+            "height": {
+              "value_type": "integer",
+              "required": true,
+              "minimum": 256,
+              "maximum": 1920,
+              "multiple_of": 64,
+              "distinct": false,
+              "same_value_as": {
+                "role": "latent",
+                "input": "height"
+              }
+            },
+            "max_shift": {
+              "value_type": "number",
+              "required": true,
+              "minimum": 0,
+              "maximum": 2,
+              "distinct": false
+            },
+            "model": {
+              "value_type": "link",
+              "required": true,
+              "distinct": false,
+              "sources": [
+                {
+                  "role": "user_lora",
+                  "output": 0
+                },
+                {
+                  "role": "denoiser",
+                  "output": 0
+                }
+              ]
+            },
+            "width": {
+              "value_type": "integer",
+              "required": true,
+              "minimum": 256,
+              "maximum": 1920,
+              "multiple_of": 64,
+              "distinct": false,
+              "same_value_as": {
+                "role": "latent",
+                "input": "width"
+              }
+            }
+          }
+        },
+        "user_lora": {
+          "class_type": "LoraLoaderModelOnly",
+          "min_count": 0,
+          "max_count": 4,
+          "inputs": {
+            "lora_name": {
+              "value_type": "part",
+              "required": true,
+              "part_type": "lora",
+              "part_names": [],
+              "distinct": true
+            },
+            "model": {
+              "value_type": "link",
+              "required": true,
+              "distinct": false,
+              "sources": [
+                {
+                  "role": "user_lora",
+                  "output": 0
+                },
+                {
+                  "role": "denoiser",
+                  "output": 0
+                }
+              ]
+            },
+            "strength_model": {
+              "value_type": "number",
+              "required": true,
+              "minimum": -2,
+              "maximum": 2,
+              "distinct": false
+            }
+          }
+        },
+        "vae": {
+          "class_type": "VAELoader",
+          "min_count": 1,
+          "max_count": 1,
+          "inputs": {
+            "vae_name": {
+              "value_type": "part",
+              "required": true,
+              "part_type": "vae",
+              "part_names": [
+                "qwen_image_vae.safetensors"
+              ],
+              "distinct": false
+            }
+          }
+        }
+      }
+    }
+  },
+  "request_contracts": [
+    {
+      "family": "mayhem_comfy_workflows",
+      "endpoint": "WORKFLOWS",
+      "required": [
+        "model",
+        "workflow"
+      ],
+      "attributes": {
+        "user": {
+          "maxLength": 512,
+          "minLength": 1,
+          "valueTypes": [
+            "string"
+          ]
+        },
+        "model": {
+          "valueTypes": [
+            "string"
+          ]
+        },
+        "workflow": {
+          "valueTypes": [
+            "object"
+          ]
+        },
+        "runtime_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "valueTypes": [
+            "string"
+          ]
+        },
+        "timeout_ms": {
+          "default": 120000,
+          "maximum": 3600000,
+          "minimum": 1000,
+          "valueTypes": [
+            "integer"
+          ]
+        },
+        "outcome_class": {
+          "maxLength": 128,
+          "minLength": 1,
+          "valueTypes": [
+            "string"
+          ]
+        },
+        "response_format": {
+          "default": "artifact",
+          "enumValues": [
+            "artifact",
+            "json"
+          ],
+          "valueTypes": [
+            "string"
+          ]
+        }
+      }
+    }
+  ],
+  "live_capacity_profiles": [
+    {
+      "modalities": {
+        "image": {
+          "unit": "pixel",
+          "maxItemsPerRequest": 4,
+          "maxItemBytes": 1620975,
+          "maxItemUnits": 1048576
+        }
+      }
+    }
+  ]
+}

--- a/src/lib/api/openMayhem.ts
+++ b/src/lib/api/openMayhem.ts
@@ -1,4 +1,5 @@
 import { KoboldApiError } from './types'
+import { isKreaImageModel, type KreaPolicy, type KreaPresentation } from './openMayhemKrea'
 
 export const OPENMAYHEM_BASE_URL = 'https://api.openmayhem.ai/v1'
 export const OPENMAYHEM_PROXY = '/api/openmayhem'
@@ -8,10 +9,14 @@ export function isOpenMayhem(baseUrl: string): boolean {
 }
 
 export type Attribute = { enumValues?: unknown[]; minimum?: number; maximum?: number; default?: unknown; multipleOf?: number; maxLength?: number; minLength?: number }
-export type OpenMayhemEndpoint = 'CHAT' | 'IMAGES' | 'AUDIO_SPEECH'
+export type OpenMayhemEndpoint = 'CHAT' | 'IMAGES' | 'AUDIO_SPEECH' | 'WORKFLOWS'
 type Contract = { endpoint: string; required?: string[]; attributes: Record<string, Attribute> }
 export interface OpenMayhemModel {
   id: string
+  name?: string
+  workflow_media?: KreaPresentation
+  workflow?: KreaPolicy
+  live_capacity_profiles?: { modalities: { image?: { unit: string; maxItemUnits: number; maxItemsPerRequest: number } } }[]
   endpoints: string[]
   context_length?: number
   availability?: string
@@ -64,6 +69,7 @@ export function loadOpenMayhemModels(refresh = false, endpoint: OpenMayhemEndpoi
 }
 
 export function isCompatibleOpenMayhemModel(model: OpenMayhemModel, endpoint: OpenMayhemEndpoint): boolean {
+  if (endpoint === 'WORKFLOWS') return isKreaImageModel(model)
   if (endpoint === 'CHAT') return isOpenMayhemChatModel(model)
   const supplied = endpoint === 'IMAGES'
     ? ['model', 'prompt', 'size', 'width', 'height', 'n', 'steps', 'cfg_scale', 'seed', 'negative_prompt']
@@ -79,6 +85,12 @@ export function isCompatibleOpenMayhemModel(model: OpenMayhemModel, endpoint: Op
     return (!voices || voices.length > 0) && (!formats || formats.some((f) => f === 'wav' || f === 'mp3'))
   }
   return true
+}
+
+/** One image picker, with endpoint-specific execution kept inside the image backend. */
+export async function loadOpenMayhemImageModels(refresh = false): Promise<OpenMayhemModel[]> {
+  const catalogs = await Promise.all([loadOpenMayhemModels(refresh, 'IMAGES'), loadOpenMayhemModels(refresh, 'WORKFLOWS')])
+  return [...new Map(catalogs.flat().map((model) => [model.id, model])).values()]
 }
 
 /** Intersect runtime contracts: a request may route to any available implementation. */

--- a/src/lib/api/openMayhemKrea.test.ts
+++ b/src/lib/api/openMayhemKrea.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import turboJson from './fixtures/krea-turbo.json'
+import qualityJson from './fixtures/krea-quality.json'
+import { kreaImageBody, isKreaImageModel, openMayhemImageLabel } from './openMayhemKrea'
+import { loadOpenMayhemImageModels, hasAvailableOpenMayhemProvider, type OpenMayhemModel } from './openMayhem'
+import { OpenMayhemImageClient } from './openMayhemMedia'
+
+const turbo = turboJson as unknown as OpenMayhemModel
+const quality = qualityJson as unknown as OpenMayhemModel
+const params = { prompt: 'A watercolor lighthouse', width: 832, height: 1216, steps: 28, cfgScale: 7, seed: 42 }
+type Graph = Record<string, { class_type: string; inputs: Record<string, unknown> }>
+const graph = (model: OpenMayhemModel, patch = {}) => kreaImageBody(model, { ...params, ...patch }).body.workflow as Graph
+const json = (data: unknown) => new Response(JSON.stringify(data), { headers: { 'Content-Type': 'application/json' } })
+afterEach(() => { vi.unstubAllGlobals(); vi.useRealTimers() })
+
+describe('Krea base images from public catalog metadata', () => {
+  it.each([turbo, quality])('builds the base graph for $name without any LoRA nodes', (model) => {
+    expect(isKreaImageModel(model)).toBe(true)
+    const nodes = graph(model)
+    expect(Object.keys(nodes)).toHaveLength(10)
+    expect(Object.values(nodes).some((node) => /lora/i.test(node.class_type))).toBe(false)
+    expect(nodes.sampling.inputs.model).toEqual(['denoiser', 0])
+    expect(nodes.positive.inputs.text).toBe(params.prompt)
+    expect(nodes.latent.inputs.batch_size).toBe(1)
+    expect(nodes.sampler.inputs.seed).toBe(42)
+    expect(nodes.denoiser.inputs.unet_name).toContain(model === turbo ? 'turbo' : 'raw')
+    expect(nodes.sampler.inputs.steps).toBe(model === turbo ? 8 : 52)
+    expect(nodes.sampler.inputs.cfg).toBe(model === turbo ? 1 : 4.5)
+  })
+  it('honors Turbo negative prompts through its published negative-prompt preset', () => {
+    const nodes = graph(turbo, { negativePrompt: 'text, watermark' })
+    expect(nodes.sampler.inputs.cfg).toBe(4)
+    expect(nodes.sampler.inputs.steps).toBe(8)
+    expect(nodes.negative.inputs.text).toBe('text, watermark')
+  })
+  it.each([[832,1216], [1920,1080], [4096,4096]])('fits %sx%s within live capacity and preserves aspect ratio', (width, height) => {
+    const nodes = graph(turbo, { width, height })
+    const w = Number(nodes.latent.inputs.width), h = Number(nodes.latent.inputs.height)
+    expect(w * h).toBeLessThanOrEqual(1048576)
+    expect(w % 64).toBe(0); expect(h % 64).toBe(0)
+    expect(Math.abs(w / h - width / height)).toBeLessThan(0.1)
+    expect(nodes.sampling.inputs.width).toBe(w)
+    expect(nodes.sampling.inputs.height).toBe(h)
+  })
+  it('rejects missing metadata, unsupported families, mandatory LoRAs, invalid defaults and inputs', () => {
+    for (const edit of [
+      (m: OpenMayhemModel) => { m.workflow_media = undefined },
+      (m: OpenMayhemModel) => { m.workflow_media!.family = 'video' },
+      (m: OpenMayhemModel) => { m.workflow!.graph_constraints.roles.user_lora.min_count = 1 },
+      (m: OpenMayhemModel) => { m.workflow_media!.presets[0].inputs[0].value = 900 },
+      (m: OpenMayhemModel) => { m.workflow!.parts[0].sha256 = 'invalid' },
+      (m: OpenMayhemModel) => { m.live_capacity_profiles![0].modalities.image!.maxItemUnits = NaN },
+      (m: OpenMayhemModel) => { m.live_capacity_profiles![0].modalities.image!.maxItemsPerRequest = 0 },
+      (m: OpenMayhemModel) => { m.request_contracts![0].required!.push('input_files') },
+    ]) { const model = structuredClone(turbo); edit(model); expect(isKreaImageModel(model)).toBe(false) }
+    expect(() => graph(turbo, { prompt: 'x'.repeat(16385) })).toThrow('16,384')
+    expect(() => graph(turbo, { width: NaN })).toThrow()
+    expect(() => graph(turbo, { seed: 1.5 })).toThrow()
+  })
+  it('uses stable IDs with friendly labels', () => {
+    expect(openMayhemImageLabel(turbo)).toBe('Krea 2 Turbo')
+    expect(openMayhemImageLabel(quality)).toBe('Krea 2 Quality')
+  })
+  it('combines paginated image/workflow catalogs and filters unavailable or unsupported workflows', async () => {
+    const zimage: OpenMayhemModel = { id: 'tongyi/z-image-turbo', endpoints: ['IMAGES'], providers_available: 1, request_contracts: [{ endpoint: 'IMAGES', required: ['model', 'prompt'], attributes: {} }] }
+    const fetchMock = vi.fn(async (url: string) => url.includes('IMAGES') ? json({ data: [zimage] })
+      : url.includes('cursor=next') ? json({ data: [quality, { ...turbo, id: 'new/turbo' }] })
+        : json({ data: [turbo, { ...turbo, id: 'busy', providers_available: 0 }, { ...turbo, id: 'stale', availability_stale: true }, { id: 'video', endpoints: ['WORKFLOWS'] }], next_cursor: 'next' }))
+    vi.stubGlobal('fetch', fetchMock)
+    const models = (await loadOpenMayhemImageModels(true)).filter(hasAvailableOpenMayhemProvider)
+    expect(models.map((m) => m.id)).toEqual([zimage.id, turbo.id, quality.id, 'new/turbo'])
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+  it.each([turbo, quality])('executes $name through workflow jobs and returns an image and seed', async (model) => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.includes('/models?')) return json({ data: url.includes('WORKFLOWS') ? [model] : [] })
+      if (url.endsWith('/workflows')) {
+        const body = JSON.parse(String(init?.body))
+        expect(body.model).toBe(model.id)
+        expect(body.workflow.sampler.inputs.seed).toBe(42)
+        expect(init?.headers).toMatchObject({ Authorization: 'Bearer example-key' })
+        return json({ id: 'job', status: 'completed', artifacts: [{ id: 'image', contentType: 'image/png' }] })
+      }
+      return new Response('image data', { headers: { 'Content-Type': 'image/png' } })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const result = await new OpenMayhemImageClient('example-key', model.id).generateImage(params)
+    expect(result).toMatchObject({ mimeType: 'image/png', seed: 42 })
+    expect(atob(result.base64)).toBe('image data')
+    expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST')).toHaveLength(1)
+  })
+})

--- a/src/lib/api/openMayhemKrea.ts
+++ b/src/lib/api/openMayhemKrea.ts
@@ -1,0 +1,150 @@
+import type { OpenMayhemModel } from './openMayhem'
+import type { ImageGenerateParams } from './imageBackend'
+
+type Rule = {
+  value_type: string; required?: boolean; fixed?: unknown; minimum?: number; maximum?: number
+  multiple_of?: number; min_length?: number; max_length?: number; enum_values?: unknown[]
+  part_type?: string; part_names?: string[]; sources?: { role: string; output: number }[]
+  same_value_as?: { role: string; input: string }
+}
+export interface KreaPresentation {
+  schema_version: number; kind: string; family: string; default_preset: string
+  presets: { id: string; inputs: { role: string; input: string; value: unknown }[] }[]
+}
+export interface KreaPolicy {
+  max_nodes: number; max_width: number; max_height: number; max_steps: number; max_artifacts: number
+  parts: { name: string; type: string; sha256: string }[]
+  dimension_bounds: { min_width: number; min_height: number; max_pixels: number; width_multiple: number; height_multiple: number }
+  graph_constraints: { output_role: string; roles: Record<string, { class_type: string; min_count: number; max_count: number; inputs: Record<string, Rule> }> }
+}
+type Graph = Record<string, { class_type: string; inputs: Record<string, unknown> }>
+// Only the reviewed base-image graph is supported. In particular, never materialize LoRA nodes.
+const classes: Record<string, string[]> = {
+  clip: ['CLIPLoader'], vae: ['VAELoader'], denoiser: ['UNETLoader'],
+  latent: ['EmptySD3LatentImage', 'EmptyLatentImage'], positive: ['CLIPTextEncode'], negative: ['CLIPTextEncode'],
+  sampling: ['ModelSamplingFlux'], sampler: ['KSampler'], decode: ['VAEDecode'], output: ['SaveImage'],
+}
+const links: Record<string, string> = {
+  'positive.clip': 'clip', 'negative.clip': 'clip', 'sampling.model': 'denoiser',
+  'sampler.model': 'sampling', 'sampler.positive': 'positive', 'sampler.negative': 'negative',
+  'sampler.latent_image': 'latent', 'decode.samples': 'sampler', 'decode.vae': 'vae', 'output.images': 'decode',
+}
+const presetFields = new Set(['sampler.steps', 'sampler.cfg', 'sampler.sampler_name', 'sampler.scheduler', 'sampling.base_shift', 'sampling.max_shift'])
+function fail(message = 'This Krea model configuration is currently unsupported. Refresh models or choose another model.'): never { throw new Error(message) }
+function positive(value: number): boolean { return Number.isFinite(value) && value > 0 }
+
+function checkValue(value: unknown, rule: Rule): void {
+  if (rule.fixed !== undefined && value !== rule.fixed || rule.enum_values && !rule.enum_values.includes(value)) fail()
+  if (rule.value_type === 'integer' || rule.value_type === 'number') {
+    if (typeof value !== 'number' || !Number.isFinite(value) || rule.value_type === 'integer' && !Number.isSafeInteger(value)
+      || value < (rule.minimum ?? -Infinity) || value > (rule.maximum ?? Infinity)
+      || rule.multiple_of !== undefined && (!positive(rule.multiple_of) || value % rule.multiple_of !== 0)) fail()
+  } else if (rule.value_type === 'string') {
+    if (typeof value !== 'string' || value.length < (rule.min_length ?? 0) || value.length > (rule.max_length ?? Infinity)) fail()
+  } else if (rule.value_type !== 'link' && rule.value_type !== 'part') fail()
+}
+
+/** Fit the slot inside both the published graph limits and every advertised live image capacity. */
+function dimensions(model: OpenMayhemModel, width: number, height: number) {
+  const policy = model.workflow!, bounds = policy.dimension_bounds
+  if (![width, height, bounds.min_width, bounds.min_height, bounds.max_pixels, bounds.width_multiple, bounds.height_multiple,
+    policy.max_width, policy.max_height].every(positive)) fail('Invalid image dimensions or model size limits.')
+  const capacities = model.live_capacity_profiles?.map((p) => p.modalities.image)
+  if (!capacities?.length || capacities.some((c) => !c || c.unit !== 'pixel' || !positive(c.maxItemUnits) || !positive(c.maxItemsPerRequest))) fail()
+  const maxPixels = Math.min(bounds.max_pixels, ...capacities.map((c) => c!.maxItemUnits))
+  const maxWidth = Math.min(policy.max_width, 4096), maxHeight = Math.min(policy.max_height, 4096)
+  const scale = Math.min(1, maxWidth / width, maxHeight / height, Math.sqrt(maxPixels / (width * height)))
+  const targetArea = width * height * scale * scale
+  let best: { width: number; height: number; score: number } | undefined
+  if (bounds.width_multiple < 8 || bounds.height_multiple < 8) fail()
+  for (let w = Math.ceil(bounds.min_width / bounds.width_multiple) * bounds.width_multiple; w <= maxWidth; w += bounds.width_multiple) {
+    for (let h = Math.ceil(bounds.min_height / bounds.height_multiple) * bounds.height_multiple; h <= maxHeight; h += bounds.height_multiple) {
+      if (w * h > maxPixels) continue
+      const score = Math.abs(Math.log((w / h) / (width / height))) * 3 + Math.abs(Math.log(w * h / targetArea))
+      if (!best || score < best.score) best = { width: w, height: h, score }
+    }
+  }
+  if (!best) fail('No supported image size is currently available for this model.')
+  return { width: best.width, height: best.height }
+}
+
+export function kreaImageBody(model: OpenMayhemModel, params: ImageGenerateParams): { body: Record<string, unknown>; seed: number } {
+  const display = model.workflow_media, policy = model.workflow
+  if (!display || display.schema_version !== 1 || display.kind !== 'image'
+    || !['krea2-turbo', 'krea2-raw'].includes(display.family) || !policy) fail()
+  const contracts = model.request_contracts?.filter((c) => c.endpoint === 'WORKFLOWS')
+  if (!model.endpoints.includes('WORKFLOWS') || !contracts?.length || contracts.some((c) =>
+    !c.attributes?.workflow || (c.required ?? []).some((key) => !['model', 'workflow', 'response_format'].includes(key))
+    || c.attributes.response_format?.enumValues && !c.attributes.response_format.enumValues.includes('artifact'))) fail()
+  if (!params.prompt.trim() || params.prompt.length > 16384 || (params.negativePrompt?.length ?? 0) > 16384) fail('Krea prompts must contain text and be at most 16,384 characters.')
+  const roles = policy.graph_constraints?.roles
+  if (!roles || policy.graph_constraints.output_role !== 'output' || ![policy.max_nodes, policy.max_artifacts, policy.max_steps].every(positive)
+    || policy.max_nodes < 10 || policy.max_artifacts < 1) fail()
+  for (const [role, definition] of Object.entries(roles)) {
+    if (!Object.prototype.hasOwnProperty.call(classes, role) && definition.min_count > 0) fail()
+  }
+  const presetId = display.family === 'krea2-turbo' && params.negativePrompt?.trim() ? 'turbo-negative' : display.default_preset
+  const preset = display.presets?.find((p) => p.id === presetId)
+  if (!preset) fail('This model has no compatible generation preset for the supplied prompt.')
+  const settings: Record<string, unknown> = {}
+  for (const entry of preset.inputs) {
+    const key = `${entry.role}.${entry.input}`
+    if (!presetFields.has(key) || key in settings) fail()
+    settings[key] = entry.value
+  }
+  if ([...presetFields].some((key) => !(key in settings)) || typeof settings['sampler.steps'] !== 'number' || settings['sampler.steps'] > policy.max_steps) fail()
+  if (params.negativePrompt?.trim() && Number(settings['sampler.cfg']) <= 1) fail('This model preset cannot apply a negative prompt.')
+  const size = dimensions(model, params.width, params.height)
+  const seedRule = roles.sampler?.inputs.seed
+  if (!seedRule || !Number.isSafeInteger(seedRule.maximum) || seedRule.maximum! < 0) fail()
+  const seed = params.seed !== undefined && params.seed >= 0 ? params.seed : Math.floor(Math.random() * (Math.min(4294967295, seedRule.maximum!) + 1))
+  Object.assign(settings, {
+    'positive.text': params.prompt, 'negative.text': params.negativePrompt ?? '', 'sampler.seed': seed,
+    'latent.width': size.width, 'latent.height': size.height, 'latent.batch_size': 1,
+    'sampling.width': size.width, 'sampling.height': size.height, 'output.filename_prefix': 'rp-suite',
+  })
+  const graph: Graph = {}
+  for (const [role, allowedClasses] of Object.entries(classes)) {
+    const definition = roles[role]
+    if (!definition || !allowedClasses.includes(definition.class_type) || definition.min_count > 1 || definition.max_count < 1) fail()
+    const inputs: Record<string, unknown> = {}
+    for (const [input, rule] of Object.entries(definition.inputs)) {
+      const key = `${role}.${input}`
+      let value: unknown
+      if (rule.value_type === 'link') {
+        const source = links[key]
+        if (!source || !rule.sources?.some((s) => s.role === source && s.output === 0)) fail()
+        value = [source, 0]
+      } else if (rule.value_type === 'part') {
+        if (rule.part_names?.length !== 1 || rule.part_type === 'lora') fail()
+        const name = rule.part_names[0]
+        if (!policy.parts?.some((p) => p.name === name && p.type === rule.part_type && /^[a-f0-9]{64}$/.test(p.sha256))) fail()
+        value = name
+      } else if (key in settings) value = settings[key]
+      else if (rule.fixed !== undefined) value = rule.fixed
+      else if (!rule.required) continue
+      else fail()
+      checkValue(value, rule)
+      inputs[input] = value
+    }
+    if (Object.keys(settings).some((key) => key.startsWith(`${role}.`) && !(key.slice(role.length + 1) in inputs))) fail()
+    graph[role] = { class_type: definition.class_type, inputs }
+  }
+  for (const [role, node] of Object.entries(graph)) for (const [input, rule] of Object.entries(roles[role].inputs)) {
+    const same = rule.same_value_as
+    if (same && node.inputs[input] !== graph[same.role]?.inputs[same.input]) fail()
+  }
+  return { body: { model: model.id, workflow: graph, response_format: 'artifact' }, seed }
+}
+
+export function isKreaImageModel(model: OpenMayhemModel): boolean {
+  try { kreaImageBody(model, { prompt: 'Compatibility check', width: 768, height: 768, steps: 1, cfgScale: 1, seed: 0 }); return true }
+  catch { return false }
+}
+
+export function openMayhemImageLabel(model: OpenMayhemModel): string {
+  if (model.workflow_media?.family === 'krea2-turbo') return 'Krea 2 Turbo'
+  if (model.workflow_media?.family === 'krea2-raw') return 'Krea 2 Quality'
+  if (model.id === 'tongyi/z-image-turbo') return 'Z-Image Turbo'
+  return model.name || model.id
+}

--- a/src/lib/api/openMayhemMedia.test.ts
+++ b/src/lib/api/openMayhemMedia.test.ts
@@ -37,6 +37,7 @@ describe('OpenMayhem media catalog and contracts', () => {
     for (const model of [{ ...image, providers_available: 0 }, { ...image, availability_stale: true },
       { ...image, request_contracts: [{ ...image.request_contracts![0], required: ['model', 'prompt', 'input_reference'] }] }]) {
       fetchMock.mockResolvedValueOnce(json({ data: [model] }))
+        .mockResolvedValueOnce(json({ data: [] }))
       await expect(availableMediaModel('IMAGES', image.id)).rejects.toThrow('no available compatible provider')
     }
     expect(fetchMock.mock.calls.every(([, init]) => !init.method)).toBe(true)
@@ -75,11 +76,11 @@ describe('OpenMayhem async media lifecycle', () => {
     expect(fetchMock.mock.calls.filter(([, init]) => init.method === 'POST')).toHaveLength(1)
     expect(fetchMock.mock.calls.every(([, init]) => init.headers.Authorization === 'Bearer key')).toBe(true)
   })
-  it('recovers the ID and cancels when Stop arrives during submission', async () => {
+  it.each(['IMAGES', 'WORKFLOWS'] as const)('recovers the ID and cancels %s when Stop arrives during submission', async (endpoint) => {
     const controller = new AbortController()
     fetchMock.mockImplementationOnce(async () => { controller.abort(); return json({ id: 'job_1', status: 'running' }) })
       .mockResolvedValueOnce(json({ status: 'cancelled' }))
-    await expect(generateOpenMayhemMedia('IMAGES', 'key', {}, controller.signal)).rejects.toMatchObject({ name: 'AbortError' })
+    await expect(generateOpenMayhemMedia(endpoint, 'key', {}, controller.signal)).rejects.toMatchObject({ name: 'AbortError' })
     expect(fetchMock.mock.calls[1]).toEqual(['/api/openmayhem/jobs/job_1', expect.objectContaining({ method: 'DELETE' })])
   })
   it('surfaces failed cancellation rather than promising the job stopped', async () => {
@@ -122,17 +123,18 @@ describe('OpenMayhem async media lifecycle', () => {
   })
   it('uses the dedicated key in the shared image factory and defaults the speech voice', async () => {
     fetchMock.mockResolvedValueOnce(json({ data: [image] }))
+      .mockResolvedValueOnce(json({ data: [] }))
       .mockResolvedValueOnce(json({ id: 'job', status: 'completed', artifacts: [{ id: 'a', contentType: 'image/png' }] }))
       .mockResolvedValueOnce(new Response('png', { headers: { 'Content-Type': 'image/png' } }))
     const backend = createImageBackend({ imageBackend: 'openmayhem', imageBackendModel: image.id, imageBackendBaseUrl: 'https://wrong.test', imageBackendUsername: 'wrong-key', imageBackendPassword: '', openMayhemApiKey: 'media-key' })
     const result = await backend.generateImage({ prompt: 'x', width: 832, height: 1216, steps: 28, cfgScale: 7 })
     expect(result.mimeType).toBe('image/png')
     expect(atob(result.base64)).toBe('png')
-    expect(fetchMock.mock.calls[1][1].headers.Authorization).toBe('Bearer media-key')
+    expect(fetchMock.mock.calls[2][1].headers.Authorization).toBe('Bearer media-key')
     fetchMock.mockResolvedValueOnce(json({ data: [speech] }))
       .mockResolvedValueOnce(json({ id: 'job', status: 'completed', artifacts: [{ id: 'a', contentType: 'audio/wav' }] }))
       .mockResolvedValueOnce(new Response('wav', { headers: { 'Content-Type': 'audio/wav' } }))
     await speakOpenMayhem('media-key', speech.id, 'Hello', '')
-    expect(JSON.parse(fetchMock.mock.calls[4][1].body)).toEqual({ model: speech.id, input: 'Hello', voice: 'default', response_format: 'wav' })
+    expect(JSON.parse(fetchMock.mock.calls[5][1].body)).toEqual({ model: speech.id, input: 'Hello', voice: 'default', response_format: 'wav' })
   })
 })

--- a/src/lib/api/openMayhemMedia.ts
+++ b/src/lib/api/openMayhemMedia.ts
@@ -1,4 +1,5 @@
-import { hasAvailableOpenMayhemProvider, loadOpenMayhemModels, openMayhemAttribute, OPENMAYHEM_PROXY, type Attribute, type OpenMayhemModel } from './openMayhem'
+import { hasAvailableOpenMayhemProvider, loadOpenMayhemModels, loadOpenMayhemImageModels, openMayhemAttribute, OPENMAYHEM_PROXY, type Attribute, type OpenMayhemModel } from './openMayhem'
+import { kreaImageBody } from './openMayhemKrea'
 import type { ImageBackend, ImageGenerateParams, ImageGenerateResult } from './imageBackend'
 
 type Endpoint = 'IMAGES' | 'AUDIO_SPEECH'
@@ -24,7 +25,7 @@ function waitForPoll(signal: AbortSignal): Promise<void> {
 }
 
 /** Submit once, poll without resubmitting, then retrieve the owned artifact through our relay. */
-export async function generateOpenMayhemMedia(endpoint: Endpoint, apiKey: string, body: Record<string, unknown>, signal?: AbortSignal): Promise<Blob> {
+export async function generateOpenMayhemMedia(endpoint: Endpoint | 'WORKFLOWS', apiKey: string, body: Record<string, unknown>, signal?: AbortSignal): Promise<Blob> {
   if (!apiKey.trim()) throw new Error('Enter your OpenMayhem media API key in Settings first.')
   signal?.throwIfAborted()
   const headers = { Authorization: `Bearer ${apiKey.trim()}` }
@@ -34,7 +35,7 @@ export async function generateOpenMayhemMedia(endpoint: Endpoint, apiKey: string
   try {
     // Keep submission alive long enough to recover its ID even if the user presses Stop.
     // Once it arrives, the aborted lifetime triggers DELETE below instead of leaving an orphan job.
-    let job: Job = await (await checkResponse(await fetch(`${OPENMAYHEM_PROXY}/${endpoint === 'IMAGES' ? 'images/generations' : 'audio/speech'}`, {
+    let job: Job = await (await checkResponse(await fetch(`${OPENMAYHEM_PROXY}/${endpoint === 'WORKFLOWS' ? 'workflows' : endpoint === 'IMAGES' ? 'images/generations' : 'audio/speech'}`, {
       method: 'POST', headers: { ...headers, 'Content-Type': 'application/json' }, body: JSON.stringify(body), signal: AbortSignal.timeout(30000),
     }))).json() as Job
     jobId = resourceId(job.id)
@@ -49,7 +50,7 @@ export async function generateOpenMayhemMedia(endpoint: Endpoint, apiKey: string
       await waitForPoll(lifetime)
       job = await (await checkResponse(await fetch(`${OPENMAYHEM_PROXY}/jobs/${jobId}`, { headers, signal: AbortSignal.any([lifetime, AbortSignal.timeout(30000)]) }))).json() as Job
     }
-    const kind = endpoint === 'IMAGES' ? 'image/' : 'audio/'
+    const kind = endpoint === 'AUDIO_SPEECH' ? 'audio/' : 'image/'
     const artifact = job.artifacts?.find((a) => (a.contentType || a.content_type)?.startsWith(kind))
     if (!artifact) throw new Error('OpenMayhem completed without a usable media artifact.')
     const res = await checkResponse(await fetch(`${OPENMAYHEM_PROXY}/artifacts/${resourceId(artifact.id)}`, { headers, signal: lifetime }))
@@ -73,7 +74,8 @@ export async function generateOpenMayhemMedia(endpoint: Endpoint, apiKey: string
 
 export async function availableMediaModel(endpoint: Endpoint, id: string): Promise<OpenMayhemModel> {
   if (!id) throw new Error(`Choose an OpenMayhem ${endpoint === 'IMAGES' ? 'image' : 'speech'} model in Settings first.`)
-  const model = (await loadOpenMayhemModels(true, endpoint)).find((m) => m.id === id && hasAvailableOpenMayhemProvider(m))
+  const catalog = await (endpoint === 'IMAGES' ? loadOpenMayhemImageModels(true) : loadOpenMayhemModels(true, endpoint))
+  const model = catalog.find((m) => m.id === id && hasAvailableOpenMayhemProvider(m))
   if (!model) throw new Error('This OpenMayhem model has no available compatible provider. Refresh Settings and choose an available model.')
   return model
 }
@@ -158,14 +160,15 @@ export function openMayhemImageBody(model: OpenMayhemModel, params: ImageGenerat
 
 export class OpenMayhemImageClient implements ImageBackend {
   constructor(private apiKey: string, private model: string) {}
-  async listModels(): Promise<string[]> { return (await loadOpenMayhemModels(true, 'IMAGES')).filter(hasAvailableOpenMayhemProvider).map((m) => m.id) }
+  async listModels(): Promise<string[]> { return (await loadOpenMayhemImageModels(true)).filter(hasAvailableOpenMayhemProvider).map((m) => m.id) }
   async generateImage(params: ImageGenerateParams, signal?: AbortSignal): Promise<ImageGenerateResult> {
     const model = await availableMediaModel('IMAGES', params.model || this.model)
-    const body = openMayhemImageBody(model, params)
-    const blob = await generateOpenMayhemMedia('IMAGES', this.apiKey, body, signal)
+    const workflow = model.endpoints.includes('WORKFLOWS') ? kreaImageBody(model, params) : undefined
+    const body = workflow?.body ?? openMayhemImageBody(model, params)
+    const blob = await generateOpenMayhemMedia(workflow ? 'WORKFLOWS' : 'IMAGES', this.apiKey, body, signal)
     const bytes = new Uint8Array(await blob.arrayBuffer())
     let binary = ''
     for (let i = 0; i < bytes.length; i += 8192) binary += String.fromCharCode(...bytes.subarray(i, i + 8192))
-    return { base64: btoa(binary), mimeType: blob.type, seed: typeof body.seed === 'number' ? body.seed : undefined }
+    return { base64: btoa(binary), mimeType: blob.type, seed: workflow?.seed ?? (typeof body.seed === 'number' ? body.seed : undefined) }
   }
 }

--- a/src/lib/hooks/useOpenMayhemModels.ts
+++ b/src/lib/hooks/useOpenMayhemModels.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { hasAvailableOpenMayhemProvider, loadOpenMayhemModels, type OpenMayhemEndpoint, type OpenMayhemModel } from '@/lib/api/openMayhem'
+import { hasAvailableOpenMayhemProvider, loadOpenMayhemModels, loadOpenMayhemImageModels, type OpenMayhemEndpoint, type OpenMayhemModel } from '@/lib/api/openMayhem'
 
 export function useOpenMayhemModels(endpoint: OpenMayhemEndpoint, enabled: boolean) {
   const [models, setModels] = useState<OpenMayhemModel[] | null>(null)
@@ -15,7 +15,7 @@ export function useOpenMayhemModels(endpoint: OpenMayhemEndpoint, enabled: boole
       if (fetching) return
       fetching = true
       try {
-        const catalog = await loadOpenMayhemModels(true, endpoint)
+        const catalog = await (endpoint === 'IMAGES' ? loadOpenMayhemImageModels(true) : loadOpenMayhemModels(true, endpoint))
         if (!disposed) setModels(catalog.filter(hasAvailableOpenMayhemProvider).sort((a, b) => a.id.localeCompare(b.id)))
       } catch { if (!disposed) setModels(null) }
       finally { fetching = false; if (!disposed) setLoading(false) }

--- a/src/lib/store/chatBackendConfig.test.ts
+++ b/src/lib/store/chatBackendConfig.test.ts
@@ -22,6 +22,7 @@ describe('chat provider credentials', () => {
     expect(useSettingsStore.getState()).toMatchObject({ ttsApiKey: '', ttsModel: '', openMayhemApiKey: 'media-secret' })
   })
   it('clears the old key and model when entering and leaving OpenMayhem', () => {
+    useSettingsStore.getState().setOpenMayhemApiKey('')
     const set = useSettingsStore.getState().setChatBackendConfig
     set({ chatBackend: 'openai-compatible', chatBackendBaseUrl: 'https://example.test/v1', chatBackendApiKey: 'old-secret', chatBackendModel: 'old-model' })
     set({ chatBackendBaseUrl: 'https://api.openmayhem.ai/v1' })
@@ -29,6 +30,27 @@ describe('chat provider credentials', () => {
     set({ chatBackendApiKey: 'mayhem-secret', chatBackendModel: 'example/chat' })
     set({ chatBackendBaseUrl: 'https://example.test/v1' })
     expect(useSettingsStore.getState()).toMatchObject({ chatBackendApiKey: '', chatBackendModel: '' })
+  })
+  it('shares one key across chat and media while keeping other providers isolated', () => {
+    const s = useSettingsStore.getState()
+    s.setOpenMayhemApiKey('shared')
+    s.setChatBackendConfig({ chatBackend: 'openai-compatible', chatBackendBaseUrl: 'https://api.openmayhem.ai/v1' })
+    expect(useSettingsStore.getState().chatBackendApiKey).toBe('shared')
+    s.setChatBackendConfig({ chatBackendApiKey: 'replacement' })
+    expect(useSettingsStore.getState().openMayhemApiKey).toBe('replacement')
+    s.setOpenMayhemApiKey('')
+    expect(useSettingsStore.getState().chatBackendApiKey).toBe('')
+    s.setChatBackendConfig({ chatBackendBaseUrl: 'https://other.test/v1', chatBackendApiKey: 'other' })
+    s.setOpenMayhemApiKey('private-to-mayhem')
+    expect(useSettingsStore.getState().chatBackendApiKey).toBe('other')
+  })
+  it('migrates saved chat-only keys and preserves the existing media key when both were configured', () => {
+    const merge = useSettingsStore.persist.getOptions().merge!
+    const current = useSettingsStore.getState()
+    const saved = { chatBackend: 'openai-compatible', chatBackendBaseUrl: 'https://api.openmayhem.ai/v1', chatBackendApiKey: 'chat-only' }
+    expect(merge(saved, current)).toMatchObject({ openMayhemApiKey: 'chat-only', chatBackendApiKey: 'chat-only' })
+    expect(merge({ ...saved, openMayhemApiKey: 'media' }, current)).toMatchObject({ openMayhemApiKey: 'media', chatBackendApiKey: 'media' })
+    expect(merge({ ...saved, chatBackendBaseUrl: 'https://other.test/v1' }, current)).toMatchObject({ openMayhemApiKey: '', chatBackendApiKey: 'chat-only' })
   })
   it('keeps credentials when choosing a different model on the same provider', () => {
     const set = useSettingsStore.getState().setChatBackendConfig

--- a/src/lib/store/useSettingsStore.ts
+++ b/src/lib/store/useSettingsStore.ts
@@ -4,6 +4,7 @@
  * image, TTS). Persisted to localStorage as `rp-settings`, with a deep `merge` for a few nested keys.
  */
 import { create } from 'zustand'
+import { isOpenMayhem } from '@/lib/api/openMayhem'
 import { persist } from 'zustand/middleware'
 import type { ChatCompletionSamplerParams, GenerationParams } from '@/lib/api/types'
 import { DEFAULT_CHAT_COMPLETION_SAMPLER } from '@/lib/api/types'
@@ -293,7 +294,7 @@ interface SettingsState {
   ttsRegion: string
   ttsVoice: string
   ttsModel: string
-  /** Shared only by OpenMayhem image generation and speech; never used for another provider. */
+  /** Shared by OpenMayhem chat, images and speech; never used for another provider. */
   openMayhemApiKey: string
   setOpenMayhemApiKey: (key: string) => void
   setVoiceConfig: (patch: Partial<{
@@ -510,7 +511,9 @@ export const useSettingsStore = create<SettingsState>()(
       ttsVoice: '',
       ttsModel: '',
       openMayhemApiKey: '',
-      setOpenMayhemApiKey: (key) => set({ openMayhemApiKey: key }),
+      setOpenMayhemApiKey: (key) => set((s) => ({ openMayhemApiKey: key,
+        ...(s.chatBackend === 'openai-compatible' && isOpenMayhem(s.chatBackendBaseUrl) ? { chatBackendApiKey: key } : {}),
+      })),
       setVoiceConfig: (patch) => set((s) => {
         const changesProvider = patch.ttsProvider !== undefined && patch.ttsProvider !== s.ttsProvider
           || patch.ttsBaseUrl !== undefined && patch.ttsBaseUrl !== s.ttsBaseUrl
@@ -525,7 +528,12 @@ export const useSettingsStore = create<SettingsState>()(
         // A provider change must not send the previous provider's secret to its replacement.
         const changesProvider = (patch.chatBackendBaseUrl !== undefined && patch.chatBackendBaseUrl !== s.chatBackendBaseUrl)
           || (patch.chatBackend !== undefined && patch.chatBackend !== s.chatBackend)
-        return changesProvider ? { chatBackendApiKey: '', chatBackendModel: '', ...patch } : patch
+        const next = changesProvider ? { chatBackendApiKey: '', chatBackendModel: '', ...patch } : { ...patch }
+        if ((patch.chatBackend ?? s.chatBackend) === 'openai-compatible' && isOpenMayhem(patch.chatBackendBaseUrl ?? s.chatBackendBaseUrl)) {
+          const key = patch.chatBackendApiKey ?? s.openMayhemApiKey
+          return { ...next, openMayhemApiKey: key, chatBackendApiKey: key }
+        }
+        return next
       }),
 
       chatCompletionSampler: DEFAULT_CHAT_COMPLETION_SAMPLER,
@@ -547,9 +555,13 @@ export const useSettingsStore = create<SettingsState>()(
       // Deep-merge just these nested keys so new tokens/params backfill instead of being hidden by an old persisted object.
       merge: (persisted, current) => {
         const p = (persisted ?? {}) as Partial<SettingsState>
+        const usesOpenMayhem = p.chatBackend === 'openai-compatible' && isOpenMayhem(p.chatBackendBaseUrl ?? '')
+        const key = p.openMayhemApiKey || (usesOpenMayhem ? p.chatBackendApiKey : '') || ''
         return {
           ...current,
           ...p,
+          openMayhemApiKey: key,
+          ...(usesOpenMayhem ? { chatBackendApiKey: key } : {}),
           themeTokensLight: { ...current.themeTokensLight, ...p.themeTokensLight },
           themeTokensDark: { ...current.themeTokensDark, ...p.themeTokensDark },
           sampler: { ...current.sampler, ...p.sampler },


### PR DESCRIPTION
﻿Krea 2 Turbo and Quality are exposed by OpenMayhem as workflow models, so they were missing from RP Suite's image picker. This adds them alongside Z-Image Turbo with friendly names and automatic request routing. Users enter one OpenMayhem key, select a model, and generate portraits, sprites, or backgrounds through the existing controls.

- Build the two supported Krea base-image graphs from live catalog metadata and published presets, without adding any LoRA nodes or workflow UI. Fit slot dimensions to graph and live provider limits; use Turbo's published negative-prompt preset when needed.
- Combine paginated image/workflow catalogs, preserve availability filtering and automatic refresh, and reuse the existing job, artifact, and cancellation handling through a fixed `/workflows` relay.
- Share the OpenMayhem key across chat, images, and voice with migration and provider-isolation coverage. An existing media key takes precedence if legacy chat/media keys differ. Restricted keys need Workflows permission for Krea.

Validation:
- 2,142 tests across 114 files passed; final metadata validation also passed its focused tests.
- Full TypeScript checks and production build passed.
- Live images generated with Z-Image Turbo, Krea 2 Turbo, and Krea 2 Quality. Turbo landscape test used a negative prompt and confirmed ten nodes, zero LoRAs, and seed 42.
- Browser checks verified the three friendly choices, saved selection, Turbo preview, and an 832x1216 Quality portrait saved/reopened from local asset storage.
- Browser Stop returned to idle without error; the provider ultimately completed that job. Cancellation does not guarantee stopped work or a refund. A transient OpenMayhem maintenance 503 was surfaced without automatic retry; a later explicit retry succeeded.

Other workflow families, reference-image editing, and optional LoRAs are outside this PR. No credentials or generated test assets are committed.
